### PR TITLE
fix(readme): сделать паучка кликабельным и начать формирование новой карты

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,23 @@
 
 ## Карта компетенций
 
+Узлы на схеме **кликабельны** — клик по ветви ведёт к карте её компетенций, клик по листу — к leaf-странице с конкретными умениями, материалами и best practices. Схема растёт постепенно: новый заполненный лист появляется новым узлом с кликом на свою страницу.
+
 ```mermaid
 graph TD
     SRE{SRE}
     SRE --> SRECulture[SRE Culture]
     SRE --> SREEngineering[SRE Engineering]
     SRE --> SREPractices[SRE Practices]
+
+    SREEngineering --> Observability[Observability]
+    Observability --> SLIAlerting[SLI-based Alerting]
+
+    click SRECulture "docs/sre-culture.md" "Перейти к SRE Culture"
+    click SREEngineering "docs/sre-engineering.md" "Перейти к SRE Engineering"
+    click SREPractices "docs/sre-practices.md" "Перейти к SRE Practices"
+    click Observability "docs/sre-engineering.md" "Перейти к Observability"
+    click SLIAlerting "docs/leaves/engineering/sli-based-alerting.md" "Открыть лист SLI-based Alerting"
 ```
 
 - **[SRE Culture](docs/sre-culture.md)** — нормы, отношения, обмен опытом. Главный объект — люди и нормы.


### PR DESCRIPTION
## Контекст

После мержа PR #2 в README остался паучок, который — несмотря на новую визуальную форму — всё ещё функционирует как **старая статичная схема**: три ветви нарисованы, но клик по узлу никуда не ведёт. Это противоречит цели «карта компетенций»: карта без переходов — это картинка, а не карта.

Цель новой схемы — она должна **постепенно формироваться** и быть **кликабельной во всех узлах и листьях**.

## Что меняется

Один атомарный коммит в `README.md`:

### 1. Кликабельность всех узлов

Все три ветви L0 (Culture, Engineering, Practices) получили `click`-директивы, ведущие к `docs/sre-{culture,engineering,practices}.md`. Mermaid в GitHub поддерживает кликабельные узлы из коробки — клик по узлу открывает соответствующий документ.

### 2. Первая цепочка L1 → L2 как демонстрация паттерна

Добавлена цепочка, показывающая, как паучок будет расти:

```text
SRE Engineering ─→ Observability ─→ SLI-based Alerting
```

- `Observability` кликает на `docs/sre-engineering.md`
- `SLI-based Alerting` кликает напрямую на `docs/leaves/engineering/sli-based-alerting.md` (эталонный лист из PR #1)

Это **минимальный пример** новой схемы — одна полная вертикаль от ветви до заполненного листа.

### 3. Нота над схемой

Добавлена короткая нота:
> Узлы на схеме **кликабельны** — клик по ветви ведёт к карте её компетенций, клик по листу — к leaf-странице с конкретными умениями, материалами и best practices. Схема растёт постепенно: новый заполненный лист появляется новым узлом с кликом на свою страницу.

Это фиксирует UX-договорённость явно: схема не статична, она растёт по мере появления заполненных листьев.

## Сознательные ограничения

- **Только одна цепочка до листа.** У Culture и Practices пока нет заполненных листьев, и добавлять placeholder-узлы в README было бы нечестно. README — это «срез готового». Placeholder-узлы для будущих листьев допустимы в `docs/sre-*.md` (где граф детальный), но не в README.
- **Без расширения существующего графа.** L1-узлы (Observability) — единственная пока появляющаяся на схеме L1-компетенция, потому что у неё есть заполненный лист в потомках. Остальные L1 появятся вместе со своими листьями.

## Дальнейшие шаги

Следующий PR — графовый ребаланс `docs/sre-*.md` (применение решений из `_inventory/overlaps.md` + чистка тулинга по политике детализации + `click`-директивы для всех L2 узлов в детальных графах).

## Test plan

- [x] `task lint` — 0 errors.
- [x] Mermaid с `click`-директивами синтаксически валиден.
- [x] Визуальный обзор на github.com: схема рендерится, клик по узлам открывает соответствующие документы.