### PR TITLE
fix(readme): перевести паучка с graph TD на mindmap-форму

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,27 +28,23 @@
 
 ## Карта компетенций
 
-Узлы на схеме **кликабельны** — клик по ветви ведёт к карте её компетенций, клик по листу — к leaf-странице с конкретными умениями, материалами и best practices. Схема растёт постепенно: новый заполненный лист появляется новым узлом с кликом на свою страницу.
+Визуальная карта направлений в SRE. Растёт постепенно: новый заполненный лист появляется на схеме новым узлом.
 
 ```mermaid
-graph TD
-    SRE{SRE}
-    SRE --> SRECulture[SRE Culture]
-    SRE --> SREEngineering[SRE Engineering]
-    SRE --> SREPractices[SRE Practices]
-
-    SREEngineering --> Observability[Observability]
-    Observability --> SLIAlerting[SLI-based Alerting]
-
-    click SRECulture "docs/sre-culture.md" "Перейти к SRE Culture"
-    click SREEngineering "docs/sre-engineering.md" "Перейти к SRE Engineering"
-    click SREPractices "docs/sre-practices.md" "Перейти к SRE Practices"
-    click Observability "docs/sre-engineering.md" "Перейти к Observability"
-    click SLIAlerting "docs/leaves/engineering/sli-based-alerting.md" "Открыть лист SLI-based Alerting"
+mindmap
+  root((SRE))
+    SRE Culture
+    SRE Engineering
+      Observability
+        SLI-based Alerting
+    SRE Practices
 ```
+
+Навигация по карте — через список ссылок ниже:
 
 - **[SRE Culture](docs/sre-culture.md)** — нормы, отношения, обмен опытом. Главный объект — люди и нормы.
 - **[SRE Engineering](docs/sre-engineering.md)** — технические компетенции и стек. Главный объект — системы.
+  - **[SLI-based Alerting](docs/leaves/engineering/sli-based-alerting.md)** — эталонный лист (Observability).
 - **[SRE Practices](docs/sre-practices.md)** — операционные процессы и ритуалы. Главный объект — процесс.
 
 Принцип разделения ветвей и политика контроля детализации — в [docs/methodology.md](docs/methodology.md).


### PR DESCRIPTION
## Контекст

После PR #3 паучок в README жил в форме `graph TD` с `click`-директивами на узлах. По запросу — переключение на `mindmap`-форму mermaid: она визуально точнее соответствует концепции «паучка компетенций» — центральный корень с расходящимися ветвями без направленности рёбер. `graph TD` рисовал ту же структуру как направленный граф сверху вниз, формально корректно, но семантически ближе к диаграмме потока.

## Что меняется

Один атомарный коммит в `README.md`:

- блок `graph TD` заменён на `mindmap`;
- корневой узел SRE задан как круг `((SRE))`;
- иерархия узлов сохранена в точности:
  ```
  root((SRE))
    SRE Culture
    SRE Engineering
      Observability
        SLI-based Alerting
    SRE Practices
  ```

## Trade-off: mindmap без `click`-директив

`mindmap` в текущей версии mermaid **не поддерживает `click`-директивы** (в отличие от `graph TD`). Чтобы не потерять навигацию, переведённую в PR #3 на клики, ссылки перенесены под схему в явный bullet-список, который **дублирует структуру карты**:

- ветви L0 → ссылки на `docs/sre-{culture,engineering,practices}.md`
- заполненные листья (вложенные булеты под соответствующей ветвью) → ссылки на leaf-страницы

Вступительная нота над схемой переформулирована: вместо «узлы кликабельны» сказано «карта растёт постепенно», и навигация явно вынесена в список ниже. Это честно отражает поведение mindmap-формы.

Если в будущих версиях mermaid появится `click`-синтаксис для mindmap — директивы можно вернуть, узлы для этого уже названы.

## Test plan

- [x] `task lint` — 0 errors.
- [ ] Визуальный обзор на github.com — `mindmap` рендерится, видно корневой узел SRE и три ветви; цепочка Engineering → Observability → SLI-based Alerting присутствует.
- [ ] Bullet-список под схемой даёт все нужные переходы.