### PR TITLE
feat(graphs): ребаланс docs/sre-*.md — применить overlaps + почистить тулинг по политике

### DIFF
--- a/docs/_inventory/overlaps.md
+++ b/docs/_inventory/overlaps.md
@@ -11,6 +11,16 @@
 - **Cross-link** — узел остаётся в одной ветви; в другой появляется ссылка на тот же лист с явной пометкой. Используется как исключение.
 - **Открыто** — решение ещё не принято.
 
+## Статус применения
+
+| Решение | Статус | Где применено |
+| ------- | ------ | ------------- |
+| Knowledge Management → Culture | ✅ Применено | Был корректно в Culture как L1, изменений в графах не потребовалось |
+| Capacity Planning → Engineering | ✅ Применено | Удалён из `sre-culture.md` (ITMG), остался в `sre-engineering.md` (RELY) |
+| DR — разделение на технику и политику | ✅ Применено | `Disaster Recovery` в Engineering/RELY; `DR Policy & Stakeholders` в Culture/ITMG |
+| SLO — разделение на три концепта | ✅ Применено | `SLO Engineering` в Engineering/RELY; `SLO Governance` в Culture/ITMG (заменил Service Management с L3); `SLO Review Ritual` в Practices/PBMG |
+| DORA Metrics → Culture | ✅ Применено | Остался в Culture/MEAS; из Practices/PEMT убран Team Metrics/DORA, добавлен `Performance Conversations` |
+
 ## Таблица пересечений
 
 | # | Узел / семейство | Где сейчас встречается | Природа дубля | Решение | Обоснование |

--- a/docs/leaves/engineering/sli-based-alerting.md
+++ b/docs/leaves/engineering/sli-based-alerting.md
@@ -1,7 +1,7 @@
 ---
 name: SLI-based Alerting
 branch: Engineering
-path: Observability/Alerting Strategy/SLI-based Alerting
+path: Observability/SLI-based Alerting
 sfia_levels: [3, 4, 5, 6]
 priority: Must Have
 status: draft

--- a/docs/sre-culture.md
+++ b/docs/sre-culture.md
@@ -15,57 +15,49 @@
 
 ## Карта компетенций
 
-Компетенции для развития в ветке `SRE Culture`:
+Граф L1+L2 в соответствии с [политикой контроля детализации](methodology.md): не более 2 уровней под ветвью, не более 7 L1 на ветвь, не более 5 L2 на L1.
 
 ```mermaid
 graph LR
     SRECulture{SRE Culture}
-    SRECulture --> RLMT[Relationship management]
-    SRECulture --> ETDL[Learning delivery]
+    SRECulture --> RLMT[Relationship Management]
+    SRECulture --> ETDL[Learning Delivery]
     SRECulture --> MEAS[Measurement]
-    SRECulture --> KNOW[Knowledge management]
-    SRECulture --> ITMG[IT management]
-    SRECulture --> OCDV[Organisational capability development]
+    SRECulture --> KNOW[Knowledge Management]
+    SRECulture --> ITMG[IT Management]
+    SRECulture --> OCDV[Organisational Capability Development]
 
-    RLMT --> PeopleManagement[People Management]
+    RLMT --> PeopleMgmt[People Management]
     RLMT --> StakeholderMgmt[Stakeholder Management]
     RLMT --> ContinuousFeedback[Continuous Feedback]
     RLMT --> DevTeamPartnership[Dev Team Partnership]
-    RLMT --> Communications
+    RLMT --> Communications[Communications]
 
     ETDL --> GameDay[Game Day / Chaos Drills]
     ETDL --> PostmortemCulture[Postmortem Culture]
-    ETDL --> IncidentResponseTraining[Incident Response Training]
-    ETDL --> Mentorship
+    ETDL --> IRTraining[Incident Response Training]
+    ETDL --> Mentorship[Mentorship]
     ETDL --> KnowledgeSharing[Knowledge Sharing]
 
-    MEAS --> SLOReview[SLO Review]
+    MEAS --> SLOBudgetReview[SLO / Budget Review]
     MEAS --> DORAMetrics[DORA Metrics]
-    MEAS --> ErrorBudgetReview[Error Budget Review]
     MEAS --> ToilMeasurement[Toil Measurement]
-    MEAS --> ReliabilityTargets[Reliability Targets]
     MEAS --> GoalSetting[Goal Setting]
 
-    KNOW --> Runbooks
-    KNOW --> Playbooks
+    KNOW --> Runbooks[Runbooks]
+    KNOW --> Playbooks[Playbooks]
     KNOW --> PostmortemDB[Postmortem Database]
-    KNOW --> ArchDecisionRecords[Architecture Decision Records]
-    KNOW --> Collaboration
+    KNOW --> ADR[Architecture Decision Records]
+    KNOW --> Collaboration[Collaboration]
 
-    ITMG --> CapacityPlanning[Capacity Planning]
     ITMG --> OnCallBudget[On-Call Budget Management]
-    ITMG --> SLAManagement[SLA Management]
-    ITMG --> DisasterRecoveryPlanning[Disaster Recovery Planning]
-    ITMG --> BudgetReliability[Reliability Budget]
-    ITMG --> ServiceManagement[Service Management]
-    ServiceManagement --> SLA
-    ServiceManagement --> SLI
-    ServiceManagement --> SLO
-    ServiceManagement --> ErrorBudget[Error Budget]
+    ITMG --> DRPolicy[DR Policy & Stakeholders]
+    ITMG --> SLOGovernance[SLO Governance]
 
-    OCDV --> SREMaturityAssessment[SRE Maturity Assessment]
-    OCDV --> SREModelAdoption[SRE Model Adoption]
-    OCDV --> RnD[Research and Development]
-    OCDV --> PoC[Proof of Concepts]
+    OCDV --> SREMaturity[SRE Maturity Assessment]
+    OCDV --> SREModel[SRE Model Adoption]
+    OCDV --> ResearchPoC[Research & PoC]
     OCDV --> TeamTopologies[Team Topologies]
 ```
+
+Бюджет узлов: 1 корень + 6 L1 + 26 L2 = **33 узла**.

--- a/docs/sre-engineering.md
+++ b/docs/sre-engineering.md
@@ -16,7 +16,7 @@
 
 ## Карта компетенций
 
-Компетенции для развития в ветке `SRE Engineering`:
+Граф L1+L2 в соответствии с [политикой контроля детализации](methodology.md): не более 2 уровней под ветвью, не более 7 L1 на ветвь, не более 5 L2 на L1. Конкретный тулинг (Prometheus, Terraform, k6 и т.п.) в графе не присутствует — он живёт в секции «Материалы» соответствующего листа.
 
 ```mermaid
 graph LR
@@ -24,124 +24,46 @@ graph LR
     SREEngineering --> OBSR[Observability]
     SREEngineering --> RELY[Reliability Engineering]
     SREEngineering --> TOIL[Toil Reduction]
-    SREEngineering --> CFMG[Configuration management]
-    SREEngineering --> ITOP[IT infrastructure]
-    SREEngineering --> PROG[Programming/scripting]
-    SREEngineering --> DBAD[Database reliability]
+    SREEngineering --> CFMG[Configuration Management]
+    SREEngineering --> ITOP[IT Infrastructure]
+    SREEngineering --> PROG[Programming / Scripting]
+    SREEngineering --> DBAD[Database Reliability]
 
     OBSR --> Metrics[Metrics]
-    Metrics --> Prometheus
-    Metrics --> VictoriaMetrics
-    Metrics --> Datadog
-    Metrics --> Grafana
     OBSR --> Logging[Logging]
-    Logging --> ELK[ELK Stack]
-    Logging --> Loki
-    Logging --> Graylog
-    Logging --> Splunk
     OBSR --> Tracing[Distributed Tracing]
-    Tracing --> Jaeger
-    Tracing --> Tempo
-    Tracing --> Zipkin
-    OBSR --> OpenTelemetry
-    OBSR --> AlertingStrategy[Alerting Strategy]
-    AlertingStrategy --> SLIBasedAlerting[SLI-Based Alerting]
-    AlertingStrategy --> ErrorBudgetBurnRate[Error Budget Burn Rate]
-    AlertingStrategy --> AlertFatigueMgmt[Alert Fatigue Management]
-    OBSR --> SyntheticMonitoring[Synthetic Monitoring]
-    OBSR --> RUMMonitoring[Real User Monitoring]
+    OBSR --> SLIAlerting[SLI-based Alerting]
+    OBSR --> EndUserMon[End-User Monitoring]
 
-    RELY --> SLOManagement[SLO Management]
-    SLOManagement --> SLIDefinition[SLI Definition]
-    SLOManagement --> SLOSetting[SLO Setting]
-    SLOManagement --> ErrorBudgetPolicy[Error Budget Policy]
-    RELY --> ChaosEngineering[Chaos Engineering]
-    ChaosEngineering --> FaultInjection[Fault Injection]
-    ChaosEngineering --> ChaosMesh[Chaos Mesh]
-    ChaosEngineering --> Litmus
+    RELY --> SLOEng[SLO Engineering]
+    RELY --> ChaosEng[Chaos Engineering]
     RELY --> CapacityPlanning[Capacity Planning]
-    CapacityPlanning --> LoadTesting[Load Testing]
-    LoadTesting --> k6
-    LoadTesting --> Gatling
-    LoadTesting --> Locust
-    CapacityPlanning --> PerformanceProfiling[Performance Profiling]
     RELY --> DisasterRecovery[Disaster Recovery]
-    DisasterRecovery --> RPO[RPO/RTO Design]
-    DisasterRecovery --> BackupValidation[Backup Validation]
-    DisasterRecovery --> FailoverTesting[Failover Testing]
     RELY --> ResiliencePatterns[Resilience Patterns]
-    ResiliencePatterns --> CircuitBreaker[Circuit Breaker]
-    ResiliencePatterns --> RetryStrategies[Retry Strategies]
-    ResiliencePatterns --> Bulkhead
-    ResiliencePatterns --> Timeout
 
-    TOIL --> ToilIdentification[Toil Identification]
-    TOIL --> ToilAutomation[Toil Automation]
-    ToilAutomation --> OperatorPattern[Operator Pattern]
-    ToilAutomation --> SelfHealing[Self-Healing Systems]
-    TOIL --> ToilTracking[Toil Tracking]
+    TOIL --> ToilIdent[Toil Identification]
+    TOIL --> ToilAutom[Toil Automation]
+    TOIL --> ToilTrack[Toil Tracking]
 
-    CFMG --> IaaC[Infrastructure as Code]
-    IaaC --> Terraform
-    IaaC --> Pulumi
-    IaaC --> Ansible
-    IaaC --> AWSCDK[AWS CDK]
-    CFMG --> GitOps
-    GitOps --> ArgoCD
-    GitOps --> FluxCD
+    CFMG --> IaC[Infrastructure as Code]
+    CFMG --> GitOps[GitOps]
 
-    ITOP --> OS[Operating System]
-    OS --> Networking
-    Networking --> NetworkTools[Network Tools]
-    NetworkTools --> NetTools[ping/traceroute/ss/netstat/iptables/dig/tcpdump/nmap/curl]
-    Networking --> Protocols
-    Protocols --> NetworkProtocols[TCP/IP/UDP/HTTP/HTTPS/gRPC/DNS/TLS]
-    OS --> Virtualization
-    OS --> MemoryStorage[Memory/Storage]
-    OS --> FS[File System]
-    OS --> POSIX[POSIX Basics]
-    OS --> Processes
-    OS --> DebugTools[Debug Tools]
-    DebugTools --> DebugTools1[ps/top/htop/atop/lsof/iotop/iostat/strace/perf/bpftrace]
-    OS --> Performance
-    OS --> Distributions
-    Distributions --> Ubuntu
-    Distributions --> RHEL
-    Distributions --> Debian
-    ITOP --> Containerization[Containerization]
-    Containerization --> Docker
-    Containerization --> Podman
-    ITOP --> ContainerOrchestration[Container Orchestration]
-    ContainerOrchestration --> Kubernetes
-    ContainerOrchestration --> Nomad
+    ITOP --> Networking[Networking]
+    ITOP --> OSPlatforms[Operating Systems]
+    ITOP --> Containers[Containerization & Orchestration]
     ITOP --> ServiceMesh[Service Mesh]
-    ServiceMesh --> Istio
-    ServiceMesh --> Linkerd
-    ITOP --> CloudProviders[Cloud Providers]
-    CloudProviders --> AWS
-    CloudProviders --> GCP[Google Cloud Platform]
-    CloudProviders --> Azure
+    ITOP --> Cloud[Cloud Providers]
 
-    PROG --> ProgrammingLanguages[Programming Languages]
-    ProgrammingLanguages --> Go
-    ProgrammingLanguages --> Python
-    ProgrammingLanguages --> Shell
-    Shell --> bash
-    Shell --> CompilingTools[Build Tools]
-    CompilingTools --> make
-    Shell --> TextManipulationTools[Text Manipulation]
-    TextManipulationTools --> TxtManipulationTools[sed/awk/cut/grep/jq/yq]
+    PROG --> Languages[Programming Languages]
+    PROG --> ShellCraft[Shell & CLI Craft]
     PROG --> CICD[CI/CD]
-    CICD --> GitHubActions[GitHub Actions]
-    CICD --> GitLabCI[GitLab CI]
-    CICD --> Jenkins
 
-    DBAD --> DBMS
-    DBMS --> SQLDB[SQL Databases]
-    DBMS --> NoSQLDB[NoSQL Databases]
-    DBAD --> DBReliability[DB Reliability]
-    DBReliability --> Replication
-    DBReliability --> BackupRestore[Backup & Restore]
-    DBReliability --> DBMonitoring[DB Monitoring]
-    DBReliability --> DBPerformance[DB Performance Tuning]
+    DBAD --> DBEngines[DB Engines]
+    DBAD --> DBReplication[Replication]
+    DBAD --> DBBackup[Backup & Restore]
+    DBAD --> DBPerf[Performance & Monitoring]
+
+    click SLIAlerting "leaves/engineering/sli-based-alerting.md" "Открыть лист SLI-based Alerting"
 ```
+
+Бюджет узлов: 1 корень + 7 L1 + 27 L2 = **35 узлов** (в пределах политики `≤ 80` на проект).

--- a/docs/sre-practices.md
+++ b/docs/sre-practices.md
@@ -16,75 +16,57 @@
 
 ## Карта компетенций
 
-Компетенции для развития в ветке `SRE Practices`:
+Граф L1+L2 в соответствии с [политикой контроля детализации](methodology.md): не более 2 уровней под ветвью, не более 7 L1 на ветвь, не более 5 L2 на L1. Конкретный тулинг (PagerDuty, Vault и т.п.) в графе не присутствует — он живёт в секции «Материалы» соответствующего листа.
 
 ```mermaid
 graph LR
     SREPractices{SRE Practices}
-    SREPractices --> USUP[Incident management]
-    SREPractices --> PBMG[Problem management]
-    SREPractices --> CHMG[Change management]
-    SREPractices --> SCTY[Information security]
-    SREPractices --> METL[Methods and tools]
-    SREPractices --> PDSV[Professional development]
-    SREPractices --> PEMT[Performance management]
+    SREPractices --> USUP[Incident Management]
+    SREPractices --> PBMG[Problem Management]
+    SREPractices --> CHMG[Change Management]
+    SREPractices --> SCTY[Information Security]
+    SREPractices --> METL[Methods & Tools]
+    SREPractices --> PDSV[Professional Development]
+    SREPractices --> PEMT[Performance Management]
 
     USUP --> IncidentResponse[Incident Response]
-    IncidentResponse --> IncidentCommander[Incident Commander Role]
-    IncidentResponse --> CommsLead[Communications Lead Role]
-    IncidentResponse --> OpsLead[Operations Lead Role]
     USUP --> EscalationPaths[Escalation Paths]
     USUP --> OnCallRotation[On-Call Rotation]
-    OnCallRotation --> OnCallHandbook[On-Call Handbook]
-    OnCallRotation --> OnCallTools[On-Call Tools]
-    OnCallTools --> PagerDuty
-    OnCallTools --> OpsGenie
-    OnCallTools --> VictorOps
-    USUP --> WarRoom[War Room / Bridge]
     USUP --> StatusPage[Status Page Management]
     USUP --> MTTR[MTTR Optimization]
 
     PBMG --> BlamelessPostmortem[Blameless Postmortem]
-    BlamelessPostmortem --> PostmortemTemplate[Postmortem Template]
-    BlamelessPostmortem --> RootCauseAnalysis[Root Cause Analysis]
-    BlamelessPostmortem --> ActionItems[Action Items Tracking]
     PBMG --> ProblemTracking[Problem Tracking]
     PBMG --> TrendAnalysis[Trend Analysis]
     PBMG --> PreventiveMeasures[Preventive Measures]
+    PBMG --> SLOReviewRitual[SLO Review Ritual]
 
     CHMG --> ProductionReadiness[Production Readiness Review]
     CHMG --> ProgressiveDelivery[Progressive Delivery]
-    ProgressiveDelivery --> CanaryRelease[Canary Release]
-    ProgressiveDelivery --> BlueGreen[Blue/Green Deployment]
-    ProgressiveDelivery --> FeatureFlags[Feature Flags]
     CHMG --> RollbackStrategy[Rollback Strategy]
     CHMG --> ErrorBudgetGating[Error Budget Gating]
     CHMG --> ChangeRiskAssessment[Change Risk Assessment]
 
-    SCTY --> VulnerabilityManagement[Vulnerability Management]
+    SCTY --> VulnerabilityMgmt[Vulnerability Management]
     SCTY --> SecuritySLOs[Security SLOs]
     SCTY --> ThreatModeling[Threat Modeling]
     SCTY --> SupplyChainSecurity[Supply Chain Security]
     SCTY --> SecretManagement[Secret Management]
-    SecretManagement --> Vault
-    SecretManagement --> AWSSM[AWS Secrets Manager]
 
     METL --> SREToolchain[SRE Toolchain]
-    SREToolchain --> MonitoringPlatform[Monitoring Platform]
-    SREToolchain --> IncidentTracking[Incident Tracking]
-    SREToolchain --> PostmortemPlatform[Postmortem Platform]
-    SREToolchain --> RunbookSystem[Runbook System]
-    METL --> PolicyManagement[Policy and Standards Management]
-    METL --> Analysis
+    METL --> PolicyManagement[Policy and Standards]
+    METL --> Analysis[Analysis]
 
     PDSV --> CareerPathing[Career Pathing for SRE]
     PDSV --> StrategyPlanning[Strategy Planning]
     PDSV --> BurnoutPrevention[Burnout Prevention]
     PDSV --> OnCallDesign[On-Call Design]
 
-    PEMT --> Mentorship
+    PEMT --> Mentorship[Mentorship]
     PEMT --> PeopleMgmt[People Management]
     PEMT --> SettingGoals[Setting Goals]
     PEMT --> PsychologicalSafety[Psychological Safety]
-    PEMT --> TeamMetrics[Team Metrics / DORA]
+    PEMT --> PerformanceConversations[Performance Conversations]
 ```
+
+Бюджет узлов: 1 корень + 7 L1 + 32 L2 = **40 узлов**.


### PR DESCRIPTION
## Контекст

После мержа PR #5 (Astro PoC) возвращаемся к высокоприоритетному пункту punch-list: графы `docs/sre-*.md` **нарушали собственную политику** из `methodology.md`:

- В графах фигурировали продукты (Prometheus, Grafana, Loki, Tempo, k6, Gatling, Terraform, Ansible, ArgoCD, Docker, Kubernetes, Istio, AWS/GCP/Azure, Go, Python, bash, jq, PagerDuty, OpsGenie, Vault, …) — около **50+ узлов-продуктов** суммарно.
- Решения из `_inventory/overlaps.md` (5 первых пересечений) были зафиксированы, но **не применены** к графам — `Knowledge Management`, `Capacity Planning`, `Disaster Recovery`, SLO-семейство, `DORA Metrics` всё ещё дублировались между ветвями.
- Глубина графов местами доходила до 3 уровней под ветвью (`Branch → L1 → L2 → L3`), что нарушает политику «не более 2 уровней».

PR закрывает эти три расхождения одновременно для всех трёх веток.

## Что меняется

4 атомарных коммита, по одной ветви:

### 1. `docs(sre-engineering)`: рестрактуризация Engineering

- **`SLO Management` → `SLO Engineering`** (overlap #4): имя точнее отражает деятельность инженерного характера и разводится с `SLO Governance` (Culture) и `SLO Review Ritual` (Practices).
- **Вычищен весь тулинг**: Prometheus, VictoriaMetrics, Datadog, Grafana, ELK, Loki, Graylog, Splunk, Jaeger, Tempo, Zipkin, OpenTelemetry, Chaos Mesh, Litmus, k6, Gatling, Locust, Terraform, Pulumi, Ansible, AWS CDK, ArgoCD, FluxCD, Docker, Podman, Kubernetes, Nomad, Istio, Linkerd, AWS, GCP, Azure, Ubuntu/RHEL/Debian, Go, Python, bash, make, sed/awk/grep/jq/yq, GitHub Actions, GitLab CI, Jenkins. **Эти продукты не теряются** — они переезжают в секцию «Материалы» соответствующих листьев по мере их создания.
- **Структурные упрощения**: `Alerting Strategy` убран как промежуточный L2 (его потомок `SLI-based Alerting` повышен до прямого L2 Observability); `Synthetic + RUM Monitoring` → `End-User Monitoring`; `Load Testing` свёрнут в `Capacity Planning`; L3-узлы под `Resilience Patterns`, `OS`, `Containerization`, `Programming Languages`, `Shell`, `Database` удалены — детализация уйдёт в leaf-страницы.
- **Click-директива** для `SLI-based Alerting` → leaf-страница (первый кликабельный L2 в детальном графе).
- **Бюджет**: 1 + 7 L1 + 27 L2 = **35 узлов**.

### 2. `docs(sre-culture)`: реструктуризация ITMG, объединения в MEAS

- **ITMG переписан** под решения overlaps:
  - убран `Capacity Planning` (overlap #2 — переехал в Engineering)
  - `Disaster Recovery Planning` → `DR Policy & Stakeholders` (overlap #3 — политическая/организационная сторона DR)
  - `Service Management` с L3-подузлами `SLA/SLI/SLO/Error Budget` → один L2 `SLO Governance` (overlap #4)
  - `Reliability Budget` и `SLA Management` поглощены `SLO Governance`
  - Итого ITMG: **3 L2** (был 6 с L3-нарушением)
- **MEAS**: `SLO Review` + `Error Budget Review` + `Reliability Targets` → `SLO / Budget Review`. Итого MEAS: **4 L2** (было 6).
- **OCDV**: `Research and Development` + `Proof of Concepts` → `Research & PoC`. Итого OCDV: **4 L2** (было 5).
- **Бюджет**: 1 + 6 L1 + 26 L2 = **33 узла**.

### 3. `docs(sre-practices)`: новые узлы + L3-узлы вынесены в leaves

- **`SLO Review Ritual`** добавлен под PBMG (overlap #4): регулярный ритуал ревью SLO/error budget.
- **`Team Metrics / DORA` → `Performance Conversations`** в PEMT (overlap #5): DORA как метрика — Culture/MEAS; разговор о росте — Practices/PEMT.
- **L3 удалены** из USUP (Incident Commander/Comms Lead/Ops Lead роли), PBMG (Postmortem Template/RCA/Action Items), CHMG (Canary/Blue-Green/Feature Flags), SCTY/SecretManagement (Vault, AWS SM), METL/SREToolchain (4 категории) — всё это идёт в leaf-страницы.
- **War Room** свёрнут в `Incident Response`; **On-Call Tools** с подсписком (PagerDuty/OpsGenie/VictorOps) удалён.
- **Бюджет**: 1 + 7 L1 + 32 L2 = **40 узлов**.

### 4. `docs(inventory)`: статусы применения + leaf frontmatter

- В `_inventory/overlaps.md` добавлена секция «Статус применения» с таблицей: все 5 первичных решений помечены как ✅ Применено с указанием конкретных мест в графах.
- `docs/leaves/engineering/sli-based-alerting.md`: фронт-маттер `path` обновлён `Observability/Alerting Strategy/SLI-based Alerting` → `Observability/SLI-based Alerting` (под уплощённую структуру).

## Замечание про общий бюджет

После ребаланса: Engineering **35** + Culture **33** + Practices **40** = **~108 узлов**. Это превышает таргет 80 из `methodology.md`. Методология явно допускает «пересмотр разбиения, а не лимита» — здесь разбиение прокручено максимально без потери смыслов. Возможные пути дальнейшего ужатия (например, `StatusPage + MTTR`, `ContinuousFeedback + Communications`, `ResiliencePatterns` как L3) — не очевидны без потери смыслов. Оставлено как есть; **пересмотр самого бюджета — отдельная задача** (возможно, поднять до 100 в methodology.md, или зайти ещё раз с холодной головой).

## Что НЕ делается в этом PR

- **Оставшиеся 6 пересечений** (Mentorship, On-Call семейство, Postmortem семейство, Incident Response, People Management, Goal Setting) — не разрешены. Они зафиксированы в `overlaps.md` в секции «Пересечения, требующие проработки». Отдельный PR.
- **`docs/sre-priorities.md`** не затронут. В нём всё ещё смешаны две оси (Must Have / Mandatory / Nice to have + реляционные «It helps to», «Mandatory/Nice to have»). Разделение осей — отдельный PR.
- **Click-директивы для L2 без leaves** не добавляются (по memory: placeholder-узлы в `/docs/sre-*.md` допустимы без click, главное чтобы в `README.md` их не было).
- **`site/` stub'ы не обновляются.** Site/ — PoC, расходный. Содержимое там самостоятельное; в эталонном листе путь уже был флэт ещё в PoC.

## Test plan

- [x] `task lint` → 0 errors, 10 файлов.
- [x] `task site:build` → 6 страниц, без warning'ов (site/ независим, не задет).
- [ ] Визуальный обзор графов на github.com: рендерятся без ошибок mermaid; все три ветки чище и без продуктов.
- [ ] Сверка с `_inventory/overlaps.md`: все 5 решений действительно отражены в трёх графах.