### PR TITLE
fix(ci): обновить Node до 22 для совместимости с Astro 5.14+

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: site/package-lock.json
 


### PR DESCRIPTION
## Проблема

После мержа PR #6 (Dependabot bump astro/@astrojs/starlight) сборка сайта в CI упала на шаге `Build Astro site`:

\`\`\`
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
\`\`\`

Лог: https://github.com/jtprogru/The-Way-of-SRE/actions/runs/26103747693/job/76761705620

Причина — Astro 5.14+ подняла минимальную поддерживаемую версию Node до 22.12. В `.github/workflows/deploy-site.yml` у `actions/setup-node@v4` была зашита версия `'20'`.

## Фикс

Один атомарный коммит, одна строка:

\`\`\`yaml
- node-version: '20'
+ node-version: '22'
\`\`\`

`setup-node@v4` с указанием `'22'` автоматически подтягивает свежий 22.x (≥ 22.12), что покрывает требование Astro и совместимо со Starlight.

## Test plan

- [ ] После мержа CI workflow `Deploy site to GitHub Pages` отрабатывает успешно.
- [ ] Сайт доступен на https://jtprogru.github.io/The-Way-of-SRE/.