### PR TITLE
fix(site): обновить social-конфиг под Starlight v0.33+ — массив вместо объекта

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -14,9 +14,13 @@ export default defineConfig({
       locales: {
         root: { label: 'Русский', lang: 'ru' },
       },
-      social: {
-        github: 'https://github.com/jtprogru/The-Way-of-SRE',
-      },
+      social: [
+        {
+          icon: 'github',
+          label: 'GitHub',
+          href: 'https://github.com/jtprogru/The-Way-of-SRE',
+        },
+      ],
       sidebar: [
         { label: 'Карта компетенций', link: '/' },
         {


### PR DESCRIPTION
## Проблема

После предыдущего фикса Node 22 (PR #8) деплой снова упал на этапе Build:

\`\`\`
[AstroUserError] Invalid config passed to starlight integration
Hint: Starlight v0.33.0 changed the \`social\` configuration syntax.
Please specify an array of link items instead of an object.
\`\`\`

Лог: https://github.com/jtprogru/The-Way-of-SRE/actions/runs/26104075887/job/76762893008

Причина — каскадный эффект Dependabot-бампа (PR #6): мажор Starlight (0.30 → 0.33+) ввёл breaking change в синтаксисе `social`. Объектный формат больше не принимается.

## Фикс

Один атомарный коммит в `site/astro.config.mjs`:

\`\`\`diff
-      social: {
-        github: 'https://github.com/jtprogru/The-Way-of-SRE',
-      },
+      social: [
+        {
+          icon: 'github',
+          label: 'GitHub',
+          href: 'https://github.com/jtprogru/The-Way-of-SRE',
+        },
+      ],
\`\`\`

## Локальная проверка

- `task site:install` — без ошибок (подтянулся свежий Starlight v0.34.x).
- `task site:build` — `6 page(s) built in 1.53s`, никаких warning/error.

После мержа deploy workflow должен пройти, сайт встанет на https://jtprogru.github.io/The-Way-of-SRE/.