### PR TITLE
feat(priorities): разделить оси priority × SFIA и синхронизировать с ребалансом

### DIFF
--- a/docs/sre-priorities.md
+++ b/docs/sre-priorities.md
@@ -1,102 +1,119 @@
 # SRE Roadmap
 
-Предполагаемая последовательность совершенствования компетенций с приоритетами.
+Документ организует компетенции трёх ветвей по **приоритету для роли SRE**. Это одна из двух осей развития; вторая — уровень зрелости инженера — хранится отдельно.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+- [Две независимые оси](#%D0%B4%D0%B2%D0%B5-%D0%BD%D0%B5%D0%B7%D0%B0%D0%B2%D0%B8%D1%81%D0%B8%D0%BC%D1%8B%D0%B5-%D0%BE%D1%81%D0%B8)
+  - [Priority — обязательность для роли](#priority--%D0%BE%D0%B1%D1%8F%D0%B7%D0%B0%D1%82%D0%B5%D0%BB%D1%8C%D0%BD%D0%BE%D1%81%D1%82%D1%8C-%D0%B4%D0%BB%D1%8F-%D1%80%D0%BE%D0%BB%D0%B8)
+  - [SFIA — уровень зрелости инженера](#sfia--%D1%83%D1%80%D0%BE%D0%B2%D0%B5%D0%BD%D1%8C-%D0%B7%D1%80%D0%B5%D0%BB%D0%BE%D1%81%D1%82%D0%B8-%D0%B8%D0%BD%D0%B6%D0%B5%D0%BD%D0%B5%D1%80%D0%B0)
 - [SRE Culture](#sre-culture)
 - [SRE Engineering](#sre-engineering)
 - [SRE Practices](#sre-practices)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+## Две независимые оси
+
+Этот документ оперирует **только осью «priority»**. Не путать с уровнем SFIA — это разные измерения. Компетенция может быть Must Have даже на L3 (Junior) или Nice to have на L6+ (Principal).
+
+### Priority — обязательность для роли
+
+- 🔴 **Must Have** — без компетенции инженер не может выполнять основную работу.
+- 🟡 **Mandatory** — компетенция, которой ожидаемо владеет любой SRE на стабильном этапе работы.
+- 🟢 **Nice to have** — расширяет возможности, но не блокирует.
+- 🔵 **On Demand** — изучается, когда проект требует.
+
+В графе ниже каждая L1-компетенция помечена цветом в соответствии с приоритетом.
+
+### SFIA — уровень зрелости инженера
+
+Хранится во фронт-маттере каждой leaf-страницы (поле `sfia_levels`), уровни 3..7 соответствуют Junior → Principal. См. [фреймворк SFIA](https://sfia-online.org/en/about-sfia/the-context-for-sfia).
+
+В этом документе SFIA-уровни **не отражаются** — для них есть отдельный источник правды.
+
 ## SRE Culture
 
 ```mermaid
 graph LR
+    classDef must fill:#ffe1e1,stroke:#cc0000,color:#222
+    classDef mandatory fill:#fff5cc,stroke:#a37e00,color:#222
+    classDef nice fill:#dffadb,stroke:#2a7d2e,color:#222
+    classDef ondemand fill:#dde7f0,stroke:#1a4a73,color:#222
+
     SRECulture{SRE Culture}
-    SRECulture-- Must Have --> MEAS[Measurement]
-    MEAS-- Mandatory --> SLOReview[SLO / Error Budget Review]
-
-    SRECulture-- Must Have --> RLMT[Relationship management]
-    RLMT-- Mandatory --> DevTeamPartnership[Dev Team Partnership]
-
-    SRECulture-- Must Have --> ETDL[Learning delivery]
-    ETDL-- Mandatory --> PostmortemCulture[Postmortem Culture]
-    ETDL-- Nice to have --> GameDay[Game Day / Chaos Drills]
-
-    SRECulture-- Must Have --> KNOW[Knowledge management]
-    KNOW-- Mandatory --> Runbooks
-    KNOW-- Mandatory --> Playbooks
-
-    RLMT-- Mandatory/Nice to have --> OCDV[Organisational capability development]
-    MEAS-- It helps to --> OCDV
-    ETDL-- It helps to --> OCDV
-    OCDV-- Mandatory/Nice to have --> ITMG[IT management]
+    SRECulture --> MEAS[Measurement]:::must
+    SRECulture --> RLMT[Relationship Management]:::must
+    SRECulture --> ETDL[Learning Delivery]:::must
+    SRECulture --> KNOW[Knowledge Management]:::must
+    SRECulture --> ITMG[IT Management]:::mandatory
+    SRECulture --> OCDV[Organisational Capability Development]:::nice
 ```
+
+L2-компетенции под каждой ветвью:
+
+- 🔴 **[Measurement](sre-culture.md)** — SLO / Budget Review, DORA Metrics, Toil Measurement, Goal Setting.
+- 🔴 **[Relationship Management](sre-culture.md)** — People Management, Stakeholder Management, Continuous Feedback, Dev Team Partnership, Communications.
+- 🔴 **[Learning Delivery](sre-culture.md)** — Game Day / Chaos Drills, Postmortem Culture, Incident Response Training, Mentorship, Knowledge Sharing.
+- 🔴 **[Knowledge Management](sre-culture.md)** — Runbooks, Playbooks, Postmortem Database, Architecture Decision Records, Collaboration.
+- 🟡 **[IT Management](sre-culture.md)** — On-Call Budget Management, DR Policy & Stakeholders, SLO Governance.
+- 🟢 **[Organisational Capability Development](sre-culture.md)** — SRE Maturity Assessment, SRE Model Adoption, Research & PoC, Team Topologies.
 
 ## SRE Engineering
 
 ```mermaid
 graph LR
+    classDef must fill:#ffe1e1,stroke:#cc0000,color:#222
+    classDef mandatory fill:#fff5cc,stroke:#a37e00,color:#222
+    classDef nice fill:#dffadb,stroke:#2a7d2e,color:#222
+    classDef ondemand fill:#dde7f0,stroke:#1a4a73,color:#222
+
     SREEngineering{SRE Engineering}
-    SREEngineering-- Must have --> OBSR[Observability]
-    SREEngineering-- Must have --> ITOP[IT infrastructure]
-    SREEngineering-- Must have --> PROG[Programming/scripting]
-
-    OBSR-- Must Have --> Metrics
-    OBSR-- Must Have --> Logging
-    OBSR-- Mandatory --> Tracing[Distributed Tracing]
-    OBSR-- Must Have --> AlertingStrategy[Alerting Strategy]
-
-    ITOP-- Must have --> OS[OS & Networking]
-    ITOP-- Mandatory --> ContainerOrchestration[Container Orchestration]
-    ITOP-- On Demand --> CloudProviders[Cloud Providers]
-
-    PROG-- Must Have --> Shell
-    PROG-- Must Have --> Go
-    PROG-- Mandatory --> CICD[CI/CD]
-
-    SREEngineering-- Must have --> RELY[Reliability Engineering]
-    RELY-- Must Have --> SLOManagement[SLO Management]
-    RELY-- Mandatory --> CapacityPlanning[Capacity Planning]
-    RELY-- Nice to have --> ChaosEngineering[Chaos Engineering]
-    RELY-- Mandatory --> DisasterRecovery[Disaster Recovery]
-
-    SREEngineering-- Mandatory --> TOIL[Toil Reduction]
-    SREEngineering-- Mandatory --> CFMG[Configuration management]
-    SREEngineering-- On Demand --> DBAD[Database reliability]
-
-    CFMG-- Mandatory --> IaaC[IaC]
-    CFMG-- Mandatory --> GitOps
+    SREEngineering --> OBSR[Observability]:::must
+    SREEngineering --> RELY[Reliability Engineering]:::must
+    SREEngineering --> ITOP[IT Infrastructure]:::must
+    SREEngineering --> PROG[Programming / Scripting]:::must
+    SREEngineering --> TOIL[Toil Reduction]:::mandatory
+    SREEngineering --> CFMG[Configuration Management]:::mandatory
+    SREEngineering --> DBAD[Database Reliability]:::ondemand
 ```
+
+L2-компетенции под каждой ветвью:
+
+- 🔴 **[Observability](sre-engineering.md)** — Metrics, Logging, Distributed Tracing, [SLI-based Alerting](leaves/engineering/sli-based-alerting.md), End-User Monitoring.
+- 🔴 **[Reliability Engineering](sre-engineering.md)** — SLO Engineering, Chaos Engineering, Capacity Planning, Disaster Recovery, Resilience Patterns.
+- 🔴 **[IT Infrastructure](sre-engineering.md)** — Networking, Operating Systems, Containerization & Orchestration, Service Mesh, Cloud Providers.
+- 🔴 **[Programming / Scripting](sre-engineering.md)** — Programming Languages, Shell & CLI Craft, CI/CD.
+- 🟡 **[Toil Reduction](sre-engineering.md)** — Toil Identification, Toil Automation, Toil Tracking.
+- 🟡 **[Configuration Management](sre-engineering.md)** — Infrastructure as Code, GitOps.
+- 🔵 **[Database Reliability](sre-engineering.md)** — DB Engines, Replication, Backup & Restore, Performance & Monitoring.
 
 ## SRE Practices
 
 ```mermaid
 graph LR
+    classDef must fill:#ffe1e1,stroke:#cc0000,color:#222
+    classDef mandatory fill:#fff5cc,stroke:#a37e00,color:#222
+    classDef nice fill:#dffadb,stroke:#2a7d2e,color:#222
+    classDef ondemand fill:#dde7f0,stroke:#1a4a73,color:#222
+
     SREPractices{SRE Practices}
-
-    SREPractices-- Must have --> USUP[Incident management]
-    USUP-- Must Have --> OnCallRotation[On-Call Rotation]
-    USUP-- Must Have --> IncidentResponse[Incident Response]
-    USUP-- Must Have --> EscalationPaths[Escalation Paths]
-
-    SREPractices-- Must have --> PBMG[Problem management]
-    PBMG-- Must Have --> BlamelessPostmortem[Blameless Postmortem]
-    PBMG-- Mandatory --> ActionItems[Action Items Tracking]
-
-    SREPractices-- Mandatory --> CHMG[Change management]
-    CHMG-- Must Have --> ProductionReadiness[Production Readiness Review]
-    CHMG-- Mandatory --> ProgressiveDelivery[Progressive Delivery]
-    CHMG-- Must Have --> ErrorBudgetGating[Error Budget Gating]
-
-    SREPractices-- Mandatory --> SCTY[Information security]
-    SREPractices-- Mandatory --> METL[Methods and tools]
-
-    SREPractices-- Mandatory --> PDSV[Professional development]
-    PDSV-- Nice to have --> PEMT[Performance management]
-    PDSV-- Must Have --> BurnoutPrevention[Burnout Prevention]
-    PDSV-- Nice to have --> KNOW[Knowledge management]
+    SREPractices --> USUP[Incident Management]:::must
+    SREPractices --> PBMG[Problem Management]:::must
+    SREPractices --> CHMG[Change Management]:::mandatory
+    SREPractices --> SCTY[Information Security]:::mandatory
+    SREPractices --> METL[Methods & Tools]:::mandatory
+    SREPractices --> PDSV[Professional Development]:::mandatory
+    SREPractices --> PEMT[Performance Management]:::mandatory
 ```
+
+L2-компетенции под каждой ветвью:
+
+- 🔴 **[Incident Management](sre-practices.md)** — Incident Response, Escalation Paths, On-Call Rotation, Status Page Management, MTTR Optimization.
+- 🔴 **[Problem Management](sre-practices.md)** — Blameless Postmortem, Problem Tracking, Trend Analysis, Preventive Measures, SLO Review Ritual.
+- 🟡 **[Change Management](sre-practices.md)** — Production Readiness Review, Progressive Delivery, Rollback Strategy, Error Budget Gating, Change Risk Assessment.
+- 🟡 **[Information Security](sre-practices.md)** — Vulnerability Management, Security SLOs, Threat Modeling, Supply Chain Security, Secret Management.
+- 🟡 **[Methods & Tools](sre-practices.md)** — SRE Toolchain, Policy and Standards, Analysis.
+- 🟡 **[Professional Development](sre-practices.md)** — Career Pathing for SRE, Strategy Planning, Burnout Prevention, On-Call Design.
+- 🟡 **[Performance Management](sre-practices.md)** — Mentorship, People Management, Setting Goals, Psychological Safety, Performance Conversations.


### PR DESCRIPTION
## Контекст

После мержа PR #7 (graph rebalance) документ `docs/sre-priorities.md` остался в двух одновременно проблемных состояниях:

1. **Методологическая проблема (изначальная):** в одном mermaid-графе смешивались две ортогональные оси — приоритет на роль (Must Have / Mandatory / Nice to have) и реляционные связки между компетенциями (стрелки «It helps to», «Mandatory/Nice to have»). Это делало непонятным, что значит стрелка от `RLMT` к `OCDV` с лейблом «Mandatory/Nice to have» — приоритет или зависимость.
2. **Стейл-имена узлов:** документ ссылался на старую структуру (`SLOManagement`, `DisasterRecoveryPlanning`, `ServiceManagement`, `TeamMetrics/DORA` и др.), которой в графах после PR #7 уже нет.

Этот PR — полный рерайт документа.

## Что меняется

Один атомарный коммит, переписан `docs/sre-priorities.md` целиком:

### Введён раздел «Две независимые оси»

- 🔴🟡🟢🔵 **priority** — обязательность для роли SRE; **только** эта ось живёт в данном документе.
- **SFIA-уровень** — зрелость инженера (L3..L7 = Junior..Principal); хранится во фронт-маттере каждого leaf'а (`sfia_levels`). **В этом документе не отражается.**

Эти оси ортогональны: компетенция может быть Must Have даже на L3 (Junior) или Nice to have на L6+ (Principal). Документ явно фиксирует это.

### Mermaid-графы переписаны

Было: одна схема `graph LR` с priority-лейблами на рёбрах + реляционными стрелками `It helps to`.

Стало: `graph LR` с 1 уровнем (Branch → L1) + цветовая разметка L1 через `classDef` по приоритету. Реляционные стрелки убраны полностью — это была мутная семантика, когда стрелка одновременно претендовала и на dependency, и на priority.

### Bullet-списки L2 под графами

Под каждым графом — список L1 с эмодзи-маркером приоритета и перечислением L2-компетенций. Все имена синхронизированы с актуальной структурой графов после ребаланса:

- `SLO Engineering` (было `SLO Management`)
- `SLI-based Alerting` как прямой L2 Observability (было L3 под `Alerting Strategy`)
- `End-User Monitoring` (объединил Synthetic + RUM)
- `Networking` как L2 IT Infrastructure
- `Containerization & Orchestration`
- `DR Policy & Stakeholders` (было `Disaster Recovery Planning`)
- `SLO Governance` (заменил `Service Management` с L3 SLA/SLI/SLO)
- `SLO / Budget Review` (свернул SLO Review + Error Budget Review + Reliability Targets)
- `Research & PoC` (свернул R&D + PoC)
- `SLO Review Ritual` в Practices/PBMG (новый)
- `Performance Conversations` в Practices/PEMT (заменил Team Metrics/DORA)
- L3 в Practices убраны (роли, шаблоны, продукты)

Единственный сейчас кликабельный L2 в bullet'ах — `SLI-based Alerting` (у него есть заполненный leaf). Остальные L2 — текст; по мере появления листьев они становятся ссылками.

### Practices: PEMT повышен до L1

В оригинальном документе `PEMT` был nested под `PDSV` как Nice to have. После ребаланса PR #7 он стал самостоятельным L1. В priorities назначен `Mandatory` как обычная управленческая практика.

## Проверки

- [x] `task toc` — `Everything is OK` (TOC регенерирован).
- [x] `task lint` — 0 errors, 10 файлов.
- [x] `task site:build` — 6 страниц без warning'ов.

## Что НЕ делается в этом PR

- **Multi-priority на L2-уровне** в этом документе не отражается. Когда у L2 нет leaf-страницы, его priority по умолчанию наследуется от L1. Когда leaf появится — priority оттуда станет источником правды.
- **Автогенерация priorities.md из frontmatter** всех leaf'ов — отдельная задача со своим PR.
- **Закрытие оставшихся 6 пересечений** из `_inventory/overlaps.md` (Mentorship, On-Call семейство, Postmortem семейство, Incident Response, People Management, Goal Setting) — следующий PR в очереди.