### PR TITLE
feat: закрыть оставшиеся 6 overlaps + добавить /priorities на сайт

### DIFF
--- a/docs/_inventory/overlaps.md
+++ b/docs/_inventory/overlaps.md
@@ -20,6 +20,12 @@
 | DR — разделение на технику и политику | ✅ Применено | `Disaster Recovery` в Engineering/RELY; `DR Policy & Stakeholders` в Culture/ITMG |
 | SLO — разделение на три концепта | ✅ Применено | `SLO Engineering` в Engineering/RELY; `SLO Governance` в Culture/ITMG (заменил Service Management с L3); `SLO Review Ritual` в Practices/PBMG |
 | DORA Metrics → Culture | ✅ Применено | Остался в Culture/MEAS; из Practices/PEMT убран Team Metrics/DORA, добавлен `Performance Conversations` |
+| Mentorship → Culture | ✅ Применено | Остался в Culture/ETDL; из Practices/PEMT удалён |
+| On-Call семейство | ✅ Зафиксировано как не-overlap | Три разных концепта с разными ветвями (Rotation, Budget, Design) — оставлены без изменений |
+| Postmortem семейство — разделение | ✅ Применено | `Blameless Postmortem` в Practices/PBMG; `Postmortem Culture` в Culture/ETDL |
+| Incident Response семейство — разделение | ✅ Применено | `Incident Response` в Practices/USUP; `Incident Response Training` в Culture/ETDL |
+| People Management → Practices | ✅ Применено | Удалён из Culture/RLMT; остался в Practices/PEMT |
+| Goal Setting → Practices | ✅ Применено | Удалён из Culture/MEAS; остался как `Setting Goals` в Practices/PEMT |
 
 ## Таблица пересечений
 
@@ -30,19 +36,14 @@
 | 3 | **Disaster Recovery** | `Engineering → RELY → Disaster Recovery` + `Culture → ITMG → Disaster Recovery Planning` | Два имени, фактически одно семейство. | **Разделение**. В `Engineering` остаётся **техника** (RPO/RTO design, backup validation, failover testing). В `Culture/ITMG` — отдельный концепт `DR Policy & Stakeholders` (принятие риска, согласование RTO с бизнесом). | Это методологически разные сущности: инженерия отказа и переговоры о допустимости отказа. Одно имя их склеивает. |
 | 4 | **SLO-семейство** (SLA / SLI / SLO / Error Budget) | `Engineering → RELY → SLO Management` (с подузлами SLI Definition, SLO Setting, Error Budget Policy) + `Culture → ITMG → Service Management` (с подузлами SLA/SLI/SLO/Error Budget) + `Culture → MEAS → SLO Review`, `Error Budget Review` | Семейство размазано по трём узлам в двух ветвях с перекрывающимися подузлами. | **Разделение** на три неперекрывающихся концепта: (1) `SLO Engineering` в `Engineering/RELY` — определение SLI, формулы, инструментирование; (2) `SLO Governance` в `Culture/ITMG` — SLA с внешними, политика error budget на уровне организации; (3) `SLO Review Ritual` в `Practices` — регулярный ритуал ревью SLO/бюджета. | Каждая из трёх сущностей имеет свой главный объект (система / нормы / процесс). Объединение их под одним именем — главный источник методологического шума. |
 | 5 | **DORA Metrics** | `Culture → MEAS → DORA Metrics` + `Practices → PEMT → Team Metrics / DORA` | Один концепт в двух ветвях с разными именами. | **Перенос** в `Culture/MEAS`. | Главный объект — метрики как инструмент разговора о состоянии (норма), а не процесс оценки людей. В `Practices/PEMT` остаётся отдельный концепт `Performance Conversations` (разговор о росте), который использует DORA как вход, но сам не является метрикой. |
+| 6 | **Mentorship** | `Culture → ETDL → Mentorship` + `Practices → PEMT → Mentorship` | Один и тот же узел в двух ветвях. | **Перенос** в `Culture/ETDL`. | Главный объект — передача знаний и развитие младших, это норма обмена опытом (Culture). В `Practices/PEMT` менторство как ритуальный аспект оценки покрывается `Performance Conversations`; отдельный узел не нужен. |
+| 7 | **On-Call семейство** | `Practices → USUP → On-Call Rotation` + `Culture → ITMG → On-Call Budget Management` + `Practices → PDSV → On-Call Design` | На первый взгляд — три узла про одну тему. По существу — **три разных концепта** с разными главными объектами. | **Не overlap.** Все три остаются. | `On-Call Rotation` — процесс ротации (кто когда дежурит) → Practices. `On-Call Budget Management` — норма распределения нагрузки на команду → Culture. `On-Call Design` — личная сторона профессионального развития (как себе строить on-call) → Practices/PDSV. Объединение исказило бы три разных смысла. |
+| 8 | **Postmortem семейство** | `Practices → PBMG → Blameless Postmortem` + `Culture → ETDL → Postmortem Culture` | За одним именем «постмортем» скрываются ритуал и норма. | **Разделение** (уже выполнено). | `Blameless Postmortem` — конкретный ритуал постмортема (формат встречи, action items, RCA) → `Practices/PBMG`. `Postmortem Culture` — норма безвиновности и психбезопасности при разборе → `Culture/ETDL`. Разные сущности, разные ветви. |
+| 9 | **Incident Response семейство** | `Practices → USUP → Incident Response` + `Culture → ETDL → Incident Response Training` | Два концепта на одной теме (реагирование). | **Разделение** (уже выполнено). | `Incident Response` — процесс реагирования на инцидент (как делаем) → Practices/USUP. `Incident Response Training` — обучение этому процессу (game day, симуляции, как норма обучения) → Culture/ETDL. |
+| 10 | **People Management** | `Culture → RLMT → People Management` + `Practices → PEMT → People Management` | Один и тот же узел в двух ветвях. | **Перенос** в `Practices/PEMT`. | Главный объект — управленческие активности (1-on-1, фидбек, развитие подчинённых), это ритуал/процесс (Practices). В `Culture/RLMT` нормы отношений уже покрыты узлами `Stakeholder Management`, `Continuous Feedback`, `Dev Team Partnership`, `Communications` — отдельный `People Management` здесь избыточен. |
+| 11 | **Goal Setting** | `Culture → MEAS → Goal Setting` + `Practices → PEMT → Setting Goals` | Один концепт в двух ветвях с похожими именами. | **Перенос** в `Practices/PEMT` (как `Setting Goals`). | Главный объект — постановка целей подчинённым (1-on-1, OKR), это ритуал управления людьми (Practices). Организационная сторона целей надёжности уже покрыта `SLO / Budget Review` в `Culture/MEAS`; отдельный `Goal Setting` там избыточен. |
 
-## Пересечения, требующие проработки
-
-Перечень остальных дублей, выявленных при ревью, — решения по ним принимаются в следующих итерациях:
-
-- **Mentorship** — `Culture → ETDL → Mentorship` vs `Practices → PEMT → Mentorship`.
-- **On-Call семейство** — `Practices → USUP → On-Call Rotation` vs `Culture → ITMG → On-Call Budget Management` vs `Practices → PDSV → On-Call Design`.
-- **Postmortem семейство** — `Practices → PBMG → Blameless Postmortem` vs `Culture → ETDL → Postmortem Culture`.
-- **Incident Response** — `Practices → USUP → Incident Response` vs `Culture → ETDL → Incident Response Training`.
-- **People Management** — `Culture → RLMT → People Management` vs `Practices → PEMT → People Management`.
-- **Goal Setting** — `Culture → MEAS → Goal Setting` vs `Practices → PEMT → Setting Goals`.
-
-Каждый из этих случаев получит строку в основной таблице по мере проработки.
+Все известные пересечения зафиксированы и решены. Новые могут появляться по мере роста графов — добавляются строкой со статусом «Открыто» и решаются в PR.
 
 ## Как пользоваться этим документом
 

--- a/docs/sre-culture.md
+++ b/docs/sre-culture.md
@@ -27,7 +27,6 @@ graph LR
     SRECulture --> ITMG[IT Management]
     SRECulture --> OCDV[Organisational Capability Development]
 
-    RLMT --> PeopleMgmt[People Management]
     RLMT --> StakeholderMgmt[Stakeholder Management]
     RLMT --> ContinuousFeedback[Continuous Feedback]
     RLMT --> DevTeamPartnership[Dev Team Partnership]
@@ -42,7 +41,6 @@ graph LR
     MEAS --> SLOBudgetReview[SLO / Budget Review]
     MEAS --> DORAMetrics[DORA Metrics]
     MEAS --> ToilMeasurement[Toil Measurement]
-    MEAS --> GoalSetting[Goal Setting]
 
     KNOW --> Runbooks[Runbooks]
     KNOW --> Playbooks[Playbooks]
@@ -60,4 +58,4 @@ graph LR
     OCDV --> TeamTopologies[Team Topologies]
 ```
 
-Бюджет узлов: 1 корень + 6 L1 + 26 L2 = **33 узла**.
+Бюджет узлов: 1 корень + 6 L1 + 24 L2 = **31 узел**.

--- a/docs/sre-practices.md
+++ b/docs/sre-practices.md
@@ -62,11 +62,10 @@ graph LR
     PDSV --> BurnoutPrevention[Burnout Prevention]
     PDSV --> OnCallDesign[On-Call Design]
 
-    PEMT --> Mentorship[Mentorship]
     PEMT --> PeopleMgmt[People Management]
     PEMT --> SettingGoals[Setting Goals]
     PEMT --> PsychologicalSafety[Psychological Safety]
     PEMT --> PerformanceConversations[Performance Conversations]
 ```
 
-Бюджет узлов: 1 корень + 7 L1 + 32 L2 = **40 узлов**.
+Бюджет узлов: 1 корень + 7 L1 + 31 L2 = **39 узлов**.

--- a/docs/sre-priorities.md
+++ b/docs/sre-priorities.md
@@ -53,8 +53,8 @@ graph LR
 
 L2-компетенции под каждой ветвью:
 
-- 🔴 **[Measurement](sre-culture.md)** — SLO / Budget Review, DORA Metrics, Toil Measurement, Goal Setting.
-- 🔴 **[Relationship Management](sre-culture.md)** — People Management, Stakeholder Management, Continuous Feedback, Dev Team Partnership, Communications.
+- 🔴 **[Measurement](sre-culture.md)** — SLO / Budget Review, DORA Metrics, Toil Measurement.
+- 🔴 **[Relationship Management](sre-culture.md)** — Stakeholder Management, Continuous Feedback, Dev Team Partnership, Communications.
 - 🔴 **[Learning Delivery](sre-culture.md)** — Game Day / Chaos Drills, Postmortem Culture, Incident Response Training, Mentorship, Knowledge Sharing.
 - 🔴 **[Knowledge Management](sre-culture.md)** — Runbooks, Playbooks, Postmortem Database, Architecture Decision Records, Collaboration.
 - 🟡 **[IT Management](sre-culture.md)** — On-Call Budget Management, DR Policy & Stakeholders, SLO Governance.
@@ -116,4 +116,4 @@ L2-компетенции под каждой ветвью:
 - 🟡 **[Information Security](sre-practices.md)** — Vulnerability Management, Security SLOs, Threat Modeling, Supply Chain Security, Secret Management.
 - 🟡 **[Methods & Tools](sre-practices.md)** — SRE Toolchain, Policy and Standards, Analysis.
 - 🟡 **[Professional Development](sre-practices.md)** — Career Pathing for SRE, Strategy Planning, Burnout Prevention, On-Call Design.
-- 🟡 **[Performance Management](sre-practices.md)** — Mentorship, People Management, Setting Goals, Psychological Safety, Performance Conversations.
+- 🟡 **[Performance Management](sre-practices.md)** — People Management, Setting Goals, Psychological Safety, Performance Conversations.

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -23,6 +23,7 @@ export default defineConfig({
       ],
       sidebar: [
         { label: 'Карта компетенций', link: '/' },
+        { label: 'Roadmap (приоритеты)', link: '/priorities/' },
         {
           label: 'Ветви',
           items: [

--- a/site/src/content/docs/priorities.md
+++ b/site/src/content/docs/priorities.md
@@ -1,0 +1,110 @@
+---
+title: SRE Roadmap — приоритеты развития
+description: Карта компетенций SRE, организованная по приоритету для роли (Must Have / Mandatory / Nice to have / On Demand). Вторая ось — уровень SFIA — хранится во фронт-маттере листьев.
+---
+
+Документ организует компетенции трёх ветвей по **приоритету для роли SRE**. Это одна из двух осей развития; вторая — уровень зрелости инженера — хранится отдельно.
+
+## Две независимые оси
+
+Этот документ оперирует **только осью «priority»**. Не путать с уровнем SFIA — это разные измерения. Компетенция может быть Must Have даже на L3 (Junior) или Nice to have на L6+ (Principal).
+
+### Priority — обязательность для роли
+
+- 🔴 **Must Have** — без компетенции инженер не может выполнять основную работу.
+- 🟡 **Mandatory** — компетенция, которой ожидаемо владеет любой SRE на стабильном этапе работы.
+- 🟢 **Nice to have** — расширяет возможности, но не блокирует.
+- 🔵 **On Demand** — изучается, когда проект требует.
+
+В графах ниже каждая L1-компетенция помечена цветом в соответствии с приоритетом.
+
+### SFIA — уровень зрелости инженера
+
+Хранится во фронт-маттере каждой leaf-страницы (поле `sfia_levels`), уровни 3..7 соответствуют Junior → Principal. См. [фреймворк SFIA](https://sfia-online.org/en/about-sfia/the-context-for-sfia).
+
+В этом документе SFIA-уровни **не отражаются** — для них есть отдельный источник правды.
+
+## SRE Culture
+
+```mermaid
+graph LR
+    classDef must fill:#ffe1e1,stroke:#cc0000,color:#222
+    classDef mandatory fill:#fff5cc,stroke:#a37e00,color:#222
+    classDef nice fill:#dffadb,stroke:#2a7d2e,color:#222
+    classDef ondemand fill:#dde7f0,stroke:#1a4a73,color:#222
+
+    SRECulture{SRE Culture}
+    SRECulture --> MEAS[Measurement]:::must
+    SRECulture --> RLMT[Relationship Management]:::must
+    SRECulture --> ETDL[Learning Delivery]:::must
+    SRECulture --> KNOW[Knowledge Management]:::must
+    SRECulture --> ITMG[IT Management]:::mandatory
+    SRECulture --> OCDV[Organisational Capability Development]:::nice
+```
+
+L2-компетенции под каждой ветвью:
+
+- 🔴 **[Measurement](/The-Way-of-SRE/sre-culture/)** — SLO / Budget Review, DORA Metrics, Toil Measurement.
+- 🔴 **[Relationship Management](/The-Way-of-SRE/sre-culture/)** — Stakeholder Management, Continuous Feedback, Dev Team Partnership, Communications.
+- 🔴 **[Learning Delivery](/The-Way-of-SRE/sre-culture/)** — Game Day / Chaos Drills, Postmortem Culture, Incident Response Training, Mentorship, Knowledge Sharing.
+- 🔴 **[Knowledge Management](/The-Way-of-SRE/sre-culture/)** — Runbooks, Playbooks, Postmortem Database, Architecture Decision Records, Collaboration.
+- 🟡 **[IT Management](/The-Way-of-SRE/sre-culture/)** — On-Call Budget Management, DR Policy & Stakeholders, SLO Governance.
+- 🟢 **[Organisational Capability Development](/The-Way-of-SRE/sre-culture/)** — SRE Maturity Assessment, SRE Model Adoption, Research & PoC, Team Topologies.
+
+## SRE Engineering
+
+```mermaid
+graph LR
+    classDef must fill:#ffe1e1,stroke:#cc0000,color:#222
+    classDef mandatory fill:#fff5cc,stroke:#a37e00,color:#222
+    classDef nice fill:#dffadb,stroke:#2a7d2e,color:#222
+    classDef ondemand fill:#dde7f0,stroke:#1a4a73,color:#222
+
+    SREEngineering{SRE Engineering}
+    SREEngineering --> OBSR[Observability]:::must
+    SREEngineering --> RELY[Reliability Engineering]:::must
+    SREEngineering --> ITOP[IT Infrastructure]:::must
+    SREEngineering --> PROG[Programming / Scripting]:::must
+    SREEngineering --> TOIL[Toil Reduction]:::mandatory
+    SREEngineering --> CFMG[Configuration Management]:::mandatory
+    SREEngineering --> DBAD[Database Reliability]:::ondemand
+```
+
+L2-компетенции под каждой ветвью:
+
+- 🔴 **[Observability](/The-Way-of-SRE/sre-engineering/)** — Metrics, Logging, Distributed Tracing, [SLI-based Alerting](/The-Way-of-SRE/leaves/engineering/sli-based-alerting/), End-User Monitoring.
+- 🔴 **[Reliability Engineering](/The-Way-of-SRE/sre-engineering/)** — SLO Engineering, Chaos Engineering, Capacity Planning, Disaster Recovery, Resilience Patterns.
+- 🔴 **[IT Infrastructure](/The-Way-of-SRE/sre-engineering/)** — Networking, Operating Systems, Containerization & Orchestration, Service Mesh, Cloud Providers.
+- 🔴 **[Programming / Scripting](/The-Way-of-SRE/sre-engineering/)** — Programming Languages, Shell & CLI Craft, CI/CD.
+- 🟡 **[Toil Reduction](/The-Way-of-SRE/sre-engineering/)** — Toil Identification, Toil Automation, Toil Tracking.
+- 🟡 **[Configuration Management](/The-Way-of-SRE/sre-engineering/)** — Infrastructure as Code, GitOps.
+- 🔵 **[Database Reliability](/The-Way-of-SRE/sre-engineering/)** — DB Engines, Replication, Backup & Restore, Performance & Monitoring.
+
+## SRE Practices
+
+```mermaid
+graph LR
+    classDef must fill:#ffe1e1,stroke:#cc0000,color:#222
+    classDef mandatory fill:#fff5cc,stroke:#a37e00,color:#222
+    classDef nice fill:#dffadb,stroke:#2a7d2e,color:#222
+    classDef ondemand fill:#dde7f0,stroke:#1a4a73,color:#222
+
+    SREPractices{SRE Practices}
+    SREPractices --> USUP[Incident Management]:::must
+    SREPractices --> PBMG[Problem Management]:::must
+    SREPractices --> CHMG[Change Management]:::mandatory
+    SREPractices --> SCTY[Information Security]:::mandatory
+    SREPractices --> METL[Methods & Tools]:::mandatory
+    SREPractices --> PDSV[Professional Development]:::mandatory
+    SREPractices --> PEMT[Performance Management]:::mandatory
+```
+
+L2-компетенции под каждой ветвью:
+
+- 🔴 **[Incident Management](/The-Way-of-SRE/sre-practices/)** — Incident Response, Escalation Paths, On-Call Rotation, Status Page Management, MTTR Optimization.
+- 🔴 **[Problem Management](/The-Way-of-SRE/sre-practices/)** — Blameless Postmortem, Problem Tracking, Trend Analysis, Preventive Measures, SLO Review Ritual.
+- 🟡 **[Change Management](/The-Way-of-SRE/sre-practices/)** — Production Readiness Review, Progressive Delivery, Rollback Strategy, Error Budget Gating, Change Risk Assessment.
+- 🟡 **[Information Security](/The-Way-of-SRE/sre-practices/)** — Vulnerability Management, Security SLOs, Threat Modeling, Supply Chain Security, Secret Management.
+- 🟡 **[Methods & Tools](/The-Way-of-SRE/sre-practices/)** — SRE Toolchain, Policy and Standards, Analysis.
+- 🟡 **[Professional Development](/The-Way-of-SRE/sre-practices/)** — Career Pathing for SRE, Strategy Planning, Burnout Prevention, On-Call Design.
+- 🟡 **[Performance Management](/The-Way-of-SRE/sre-practices/)** — People Management, Setting Goals, Psychological Safety, Performance Conversations.


### PR DESCRIPTION
## Контекст

В `docs/_inventory/overlaps.md` со времён PR #1 висел список из 6 пересечений «Пересечения, требующие проработки». Этот PR закрывает их все, применяет решения к графам, синхронизирует `sre-priorities.md` и **зеркалит roadmap на сайт** (отдельная страница `/priorities/`).

## Решения по 6 overlaps

| # | Узел | Решение | Что меняется в графах |
|---|------|---------|------------------------|
| 6 | **Mentorship** | Перенос в `Culture/ETDL` | Удалён из `Practices/PEMT` |
| 7 | **On-Call семейство** | Не overlap — три разных концепта (Rotation/Budget/Design) | Без изменений, зафиксировано формально |
| 8 | **Postmortem семейство** | Разделение (уже было) | Без изменений, документирован принцип |
| 9 | **Incident Response семейство** | Разделение (уже было) | Без изменений, документирован принцип |
| 10 | **People Management** | Перенос в `Practices/PEMT` | Удалён из `Culture/RLMT` |
| 11 | **Goal Setting** | Перенос в `Practices/PEMT` (как `Setting Goals`) | Удалён из `Culture/MEAS` |

Логика:

- **Mentorship** — главный объект (передача знаний, развитие младших) — норма обмена опытом (Culture). В Practices/PEMT менторская сторона уже покрыта `Performance Conversations`.
- **People Management** — управленческая активность (1-on-1, фидбек) — ритуал (Practices). В Culture/RLMT нормы отношений уже покрыты Stakeholder Mgmt / Continuous Feedback / Dev Team Partnership / Communications.
- **Goal Setting** — постановка целей подчинённым (1-on-1, OKR) — ритуал управления (Practices). Организационные цели надёжности уже покрыты `SLO / Budget Review` в Culture/MEAS.

## Что меняется

4 атомарных коммита:

### 1. `docs(inventory)`: закрыть 6 пересечений в overlaps.md

- Основная таблица: 5 → 11 строк.
- Секция «Пересечения, требующие проработки» удалена (была пустой после переноса).
- Таблица «Статус применения»: 5 → 11 строк.
- Добавлена закрывающая фраза про процесс.

### 2. `docs(graphs)`: применить overlaps 10/11/6

- `Culture/RLMT`: удалён `People Management` → 4 L2.
- `Culture/MEAS`: удалён `Goal Setting` → 3 L2.
- `Practices/PEMT`: удалён `Mentorship` → 4 L2.

Бюджет проекта: **108 → 105 узлов** (Culture 33→31, Practices 40→39).

### 3. `docs(priorities)`: синхронизировать L2-списки

Bullet-списки `sre-priorities.md` приведены в соответствие с обновлёнными графами. Mermaid-графы (только L1) не затронуты.

### 4. `feat(site)`: добавить /priorities + sidebar

- Создана `site/src/content/docs/priorities.md` — Starlight-формат страницы с теми же mermaid-графами и bullet-списками, что и в `/docs/sre-priorities.md`. Ссылки переведены на сайтовые URL.
- `site/astro.config.mjs`: sidebar пополнен пунктом `Roadmap (приоритеты)` между «Карта компетенций» и группой «Ветви».
- Эталонный лист `SLI-based Alerting` в bullet'е Engineering/Observability — кликабелен и ведёт на сайт-страницу.

## Проверки

- [x] `task lint` → 0 errors (10 файлов в /docs).
- [x] `task site:build` → 7 page(s) (было 6, +/priorities/), без warning'ов.

## Что осталось по плану

- 🟡 Горизонтальный заход по листьям — создать черновики leaf-страниц для Must Have узлов всех трёх ветвей (по шаблону `docs/leaves/_template.md`). Это даст реальное наполнение проекта.
- 🟢 Разбор tlroadmap.io — одностраничный конспект «что берём / что не берём» по UX.
- 🐛 Опечатка `LCIENSE` (нужен `LICENSE.md`) — badge в README ведёт в 404.