### PR TITLE
docs(site): актуализировать site/README.md — убрать PoC-статус

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -1,8 +1,8 @@
-# The Way of SRE — Site (PoC)
+# The Way of SRE — сайт
 
-Astro Starlight PoC для визуализации карты компетенций SRE.
+Astro Starlight реализация карты компетенций SRE. Публикуется на GitHub Pages.
 
-**Статус:** Proof of Concept. Проверяем, подходит ли Astro Starlight как целевая платформа для роадмапа взамен mermaid-схем в `/docs`.
+**URL:** <https://jtprogru.github.io/The-Way-of-SRE/>
 
 ## Запуск из корня репо
 
@@ -26,27 +26,29 @@ cd site && npm install && npm run dev
 
 Автоматический через GitHub Actions (`.github/workflows/deploy-site.yml`): на каждый push в `main`, затрагивающий `site/`, билд публикуется на GitHub Pages.
 
-URL после первого успешного деплоя: <https://jtprogru.github.io/The-Way-of-SRE/>.
+## Что внутри
 
-Чтобы деплой заработал, в настройках репо нужно включить **Settings → Pages → Source: GitHub Actions** (одноразово, скриптом не делается).
+- **Данные** — `src/data/roadmap.ts`. Единый источник правды о структуре графа (типы `Branch` / `L1` / `Leaf`). Изменение здесь автоматически отражается в `Spider` и `BranchView`.
+- **Компоненты визуализации**:
+  - `src/components/Spider.astro` — главная страница, overview всех ветвей через inline SVG. Кликабелен **текст** узла, не фигура.
+  - `src/components/BranchView.astro` — страницы ветвей (`variant="navigation"`) и priorities-страница (`variant="priority"` с цветовой кодировкой 🔴🟡🟢🔵).
+- **Контент**:
+  - `src/content/docs/index.mdx` — главная.
+  - `src/content/docs/sre-{culture,engineering,practices}.mdx` — страницы ветвей.
+  - `src/content/docs/priorities.mdx` — roadmap по приоритетам.
+  - `src/content/docs/leaves/<branch>/<slug>.md` — leaf-страницы (10 на момент написания).
+- **Навигация** — `astro.config.mjs`, поле `sidebar`. Список листьев в sidebar поддерживается вручную параллельно с фактическими файлами.
+- **Стили** — `src/styles/custom.css`.
 
-## Что внутри PoC
+## Как добавить новый лист
 
-- Главная страница со spider-картой (`src/content/docs/index.mdx`).
-- Компонент `Spider.astro` — inline SVG с `<a>`-тегами в текстовых узлах. **Кликабелен только текст**, не сами узлы. Это подтверждение концепции: текст-как-ссылка работает.
-- Три страницы ветвей (Culture / Engineering / Practices) — стабы для проверки навигации.
-- Один лист (`leaves/engineering/sli-based-alerting`) — изначально перенесён из `/docs/leaves` для проверки полной цепочки навигации со spider'а.
+1. Создать файл `src/content/docs/leaves/<branch>/<slug>.md` по шаблону [`docs/leaves/_template.md`](../docs/leaves/_template.md) (Starlight-формат: `title`/`description` во фронт-маттере, метаданные через `:::note` callout).
+2. Добавить запись в sidebar `astro.config.mjs` (раздел `Листья` → соответствующая ветвь).
+3. Добавить `href: '/leaves/<branch>/<slug>/'` в соответствующую запись `src/data/roadmap.ts` (на узле L2 или L1, к которому относится лист).
+4. Локально проверить: `task site:build` (страница появится в списке роутов) и `task site:dev` (открыть `/The-Way-of-SRE/leaves/<branch>/<slug>/`).
 
-## Чего нет в PoC
+## Архитектурные ограничения
 
-- Полная миграция содержимого из `/docs` — намеренно не сделана. PoC — это образец, не финал.
-- Расширение spider до полной карты — только цепочка `SRE → Engineering → Observability → SLI-based Alerting` для проверки L2-навигации.
-
-## Решение по миграции
-
-После просмотра PoC принимается одно из решений:
-
-- **Мигрируем.** Тогда: переносим всё содержимое из `/docs`, настраиваем деплой, переписываем корневой README как landing на сайт.
-- **Не мигрируем.** Тогда: `site/` удаляется, возвращаемся к mermaid-форме в README.
-
-До принятия решения `site/` существует параллельно с `/docs` и ничего в основном проекте не меняет.
+- Mermaid на сайте не рендерится (Starlight без плагина). Графы строятся через `<Spider />` и `<BranchView />`. Mermaid-схемы остаются только в `/docs/sre-*.md` — для рендера в GitHub UI.
+- Кликается **текст** узла, не сама фигура. Принцип сохраняется при любом редактировании SVG-компонента.
+- Leaf-страницы хранятся **только** здесь. В `/docs/leaves/` живёт только шаблон (`_template.md`).


### PR DESCRIPTION
## Summary

- Заголовок и lead без «PoC», добавлен публичный URL.
- Удалены устаревшие секции «Чего нет в PoC», «Решение по миграции» и инструкция по одноразовой настройке GitHub Pages.
- Новые секции «Что внутри», «Как добавить новый лист», «Архитектурные ограничения» отражают актуальное состояние сайта.

## Контекст

`site/README.md` оставался в формулировках начала PoC: «Проверяем, подходит ли Astro Starlight...», «Один лист (sli-based-alerting) — изначально перенесён из /docs/leaves для проверки полной цепочки навигации», «До принятия решения site/ существует параллельно с /docs». Все эти утверждения уже не соответствуют реальности:

- Миграция принята и завершена (PR #5, #8, #9).
- Сайт задеплоен на <https://jtprogru.github.io/The-Way-of-SRE/>.
- На сайте 10 leaf-страниц (PR #14).
- Mermaid заменён на inline SVG (PR #12).
- `/docs/leaves/<branch>/*` дедуплицирован, site — единственный источник листьев (PR #15).

Новый README:
- Описывает реальный состав сайта (данные → компоненты → контент → навигация → стили).
- Даёт пошаговый чеклист «как добавить новый лист», синхронизированный с правилами заполнения шаблона из `docs/leaves/_template.md` (создать файл → обновить sidebar → обновить roadmap.ts → локально проверить).
- Фиксирует три архитектурных ограничения, которые легко нарушить случайно: mermaid → SVG, кликается текст, листья только в `site/`.

## Test plan

- [x] Прочитать README в GitHub UI после мержа — все ссылки и якоря корректны.
- [x] Содержимое README сверено с фактической структурой `site/src/` (компоненты, контент, navigation).
- [ ] При следующем добавлении листа — пройти по чеклисту «Как добавить новый лист» и убедиться, что инструкция исчерпывающая.

## Не входит в этот PR

- Никаких изменений в самом сайте (контент, конфиг, компоненты). Только README.