### PR TITLE
fix(site): починить 404 на /favicon.svg

### DIFF
--- a/site/public/favicon.svg
+++ b/site/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="The Way of SRE">
+  <style>
+    :root { --c: #1a1a1a; }
+    @media (prefers-color-scheme: dark) { :root { --c: #f5f5f5; } }
+    .edge { stroke: var(--c); stroke-width: 4; stroke-linecap: round; fill: none; }
+    .node { fill: var(--c); }
+  </style>
+  <line class="edge" x1="32" y1="32" x2="12" y2="18" />
+  <line class="edge" x1="32" y1="32" x2="54" y2="22" />
+  <line class="edge" x1="32" y1="32" x2="32" y2="56" />
+  <circle class="node" cx="32" cy="32" r="8" />
+  <circle class="node" cx="12" cy="18" r="5" />
+  <circle class="node" cx="54" cy="22" r="5" />
+  <circle class="node" cx="32" cy="56" r="5" />
+</svg>


### PR DESCRIPTION
## Summary

- Добавлен `site/public/favicon.svg`.
- Устранён 404 на запрос `/favicon.svg`, который Starlight автоматически вставляет в `<head>` каждой страницы.

## Контекст

Из dev-сервера приходил warning:

\`\`\`
[WARN] [router] A getStaticPaths() route pattern was matched, but no matching static path was found for requested path /favicon.svg.
[404] /favicon.svg
\`\`\`

Starlight по умолчанию вставляет в head:
\`\`\`html
<link rel="shortcut icon" href="/The-Way-of-SRE/favicon.svg" type="image/svg+xml">
\`\`\`

До этого коммита `site/public/` был пуст — ссылка вела в никуда.

## Что сделано

`site/public/favicon.svg` — простая монохромная векторная иконка из 4 узлов: центральный (SRE root) и 3 ветви (Culture / Engineering / Practices). Визуально согласована с Spider-картой на сайте. CSS внутри SVG поддерживает light/dark через `prefers-color-scheme`.

## Test plan

- [x] Clean rebuild: `rm -rf site/dist && task site:build` — `site/dist/favicon.svg` присутствует.
- [x] В HTML `<head>` сгенерированных страниц: `<link rel="shortcut icon" href="/The-Way-of-SRE/favicon.svg" type="image/svg+xml">`.
- [x] 18 страниц собираются без ошибок, новых warning'ов нет.
- [ ] После deploy: в браузере на live-сайте — иконка появляется на табе; запрос `/favicon.svg` отвечает 200.