### PR TITLE
feat(site): визуальный overhaul главной — палитра, иерархия, мобайл

### DIFF
--- a/src/components/BranchView.astro
+++ b/src/components/BranchView.astro
@@ -29,11 +29,31 @@ const link = (path: string) => `${base}${path}`;
 // Layout constants
 const ROW_H = 36;
 const BRANCH_X = 30;
-const L1_X = 280;
-const LEAF_X = 560;
-const NODE_W = 220;
+const COLUMN_GAP = 60;
+const MIN_NODE_W = 200;
 const NODE_H = 30;
+const NODE_PAD_X = 28;
 const TOP_PAD = 20;
+const CHAR_W_BRANCH = 8.2;
+const CHAR_W_L1 = 7.4;
+const CHAR_W_LEAF = 7.4;
+
+function estimateWidth(label: string, charW: number): number {
+  return Math.max(MIN_NODE_W, Math.round(label.length * charW) + NODE_PAD_X);
+}
+
+const branchColW = estimateWidth(branch.label, CHAR_W_BRANCH);
+let l1ColW = MIN_NODE_W;
+let leafColW = MIN_NODE_W;
+for (const l1 of branch.l1) {
+  l1ColW = Math.max(l1ColW, estimateWidth(l1.label, CHAR_W_L1));
+  for (const leaf of l1.leaves ?? []) {
+    leafColW = Math.max(leafColW, estimateWidth(leaf.label, CHAR_W_LEAF));
+  }
+}
+
+const L1_X = BRANCH_X + branchColW + COLUMN_GAP;
+const LEAF_X = L1_X + l1ColW + COLUMN_GAP;
 
 interface Node {
   kind: 'branch' | 'l1' | 'leaf';
@@ -73,14 +93,14 @@ nodes.push({
   label: branch.label,
   x: BRANCH_X,
   y: branchCenter - NODE_H / 2,
-  width: NODE_W,
+  width: branchColW,
   height: NODE_H,
 });
 
 // L1s + leaves
 for (const [l1i, l1] of branch.l1.entries()) {
   edges.push({
-    x1: BRANCH_X + NODE_W,
+    x1: BRANCH_X + branchColW,
     y1: branchCenter,
     x2: L1_X,
     y2: l1Centers[l1i],
@@ -91,14 +111,14 @@ for (const [l1i, l1] of branch.l1.entries()) {
     label: l1.label,
     x: L1_X,
     y: l1Centers[l1i] - NODE_H / 2,
-    width: NODE_W,
+    width: l1ColW,
     height: NODE_H,
     href: `${branch.href}#${l1.id}`,
   });
 
   for (const leaf of l1.leaves ?? []) {
     edges.push({
-      x1: L1_X + NODE_W,
+      x1: L1_X + l1ColW,
       y1: l1Centers[l1i],
       x2: LEAF_X,
       y2: l1Centers[l1i],
@@ -108,7 +128,7 @@ for (const [l1i, l1] of branch.l1.entries()) {
       label: leaf.label,
       x: LEAF_X,
       y: l1Centers[l1i] - NODE_H / 2,
-      width: NODE_W,
+      width: leafColW,
       height: NODE_H,
       href: leaf.href,
     });
@@ -116,11 +136,11 @@ for (const [l1i, l1] of branch.l1.entries()) {
 }
 
 const hasAnyLeaves = branch.l1.some((l1) => l1.leaves && l1.leaves.length > 0);
-const viewBoxW = (hasAnyLeaves ? LEAF_X + NODE_W : L1_X + NODE_W) + 20;
+const viewBoxW = (hasAnyLeaves ? LEAF_X + leafColW : L1_X + l1ColW) + 20;
 const viewBoxH = totalHeight;
 ---
 
-<figure class="branchview-figure" data-variant={variant}>
+<figure class="branchview-figure" data-variant={variant} data-branch={branch.id}>
   <svg
     class="branchview"
     viewBox={`0 0 ${viewBoxW} ${viewBoxH}`}
@@ -167,6 +187,43 @@ const viewBoxH = totalHeight;
     margin: 1.5rem 0 2rem;
   }
 
+  /*
+   * Палитра по ветвям — соответствует Spider.astro (одна цветовая
+   * семантика на всех страницах). Применяется только в navigation-
+   * варианте; priority-вариант оставлен с собственной цветовой схемой
+   * через .priority-* классы (приоритеты — другая ось смысла).
+   */
+  .branchview-figure[data-branch='culture'] {
+    --bc: #d97706;
+    --bc-low: #fef3c7;
+    --bc-text: #78350f;
+  }
+  .branchview-figure[data-branch='engineering'] {
+    --bc: #0d9488;
+    --bc-low: #ccfbf1;
+    --bc-text: #134e4a;
+  }
+  .branchview-figure[data-branch='practices'] {
+    --bc: #6366f1;
+    --bc-low: #e0e7ff;
+    --bc-text: #312e81;
+  }
+  :root[data-theme='dark'] .branchview-figure[data-branch='culture'] {
+    --bc: #f59e0b;
+    --bc-low: #44301a;
+    --bc-text: #fde68a;
+  }
+  :root[data-theme='dark'] .branchview-figure[data-branch='engineering'] {
+    --bc: #2dd4bf;
+    --bc-low: #133b37;
+    --bc-text: #99f6e4;
+  }
+  :root[data-theme='dark'] .branchview-figure[data-branch='practices'] {
+    --bc: #818cf8;
+    --bc-low: #1f1f4e;
+    --bc-text: #c7d2fe;
+  }
+
   .branchview {
     width: 100%;
     height: auto;
@@ -175,7 +232,8 @@ const viewBoxH = totalHeight;
 
   .branchview .edge {
     stroke: var(--sl-color-gray-4);
-    stroke-width: 1.5;
+    stroke-width: 1.6;
+    opacity: 0.85;
   }
 
   .branchview .node rect {
@@ -193,17 +251,47 @@ const viewBoxH = totalHeight;
     user-select: none;
   }
 
-  .branchview .node-branch rect {
+  /* Navigation variant: окраска по ветви */
+  .branchview-figure[data-variant='navigation'] .edge {
+    stroke: var(--bc);
+    opacity: 0.55;
+    stroke-width: 2;
+  }
+  .branchview-figure[data-variant='navigation'] .node-branch rect {
+    fill: var(--bc);
+    stroke: var(--bc);
+  }
+  .branchview-figure[data-variant='navigation'] .node-branch text {
+    fill: #fff;
+    font-weight: 700;
+  }
+  .branchview-figure[data-variant='navigation'] .node-l1 rect {
+    fill: var(--sl-color-bg);
+    stroke: var(--bc);
+    stroke-width: 1.5;
+  }
+  .branchview-figure[data-variant='navigation'] .node-leaf rect {
+    fill: var(--bc-low);
+    stroke: var(--bc);
+    stroke-width: 1.8;
+  }
+  .branchview-figure[data-variant='navigation'] .node-leaf text {
+    fill: var(--bc-text);
+    font-weight: 600;
+  }
+
+  /* Priority variant: оставлен с исходной цветовой схемой (по приоритетам) */
+  .branchview-figure[data-variant='priority'] .node-branch rect {
     fill: var(--sl-color-accent);
     stroke: var(--sl-color-accent);
   }
 
-  .branchview .node-branch text {
+  .branchview-figure[data-variant='priority'] .node-branch text {
     fill: var(--sl-color-white);
     font-weight: 700;
   }
 
-  .branchview .node-leaf rect {
+  .branchview-figure[data-variant='priority'] .node-leaf rect {
     fill: var(--sl-color-accent-low);
     stroke: var(--sl-color-accent);
     stroke-width: 2;

--- a/src/components/BranchView.astro
+++ b/src/components/BranchView.astro
@@ -230,6 +230,30 @@ const viewBoxH = totalHeight;
     display: block;
   }
 
+  /* Мобильный режим — см. Spider.astro: горизонтальный скролл с подсказкой */
+  @media (max-width: 900px) {
+    .branchview-figure {
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      margin-inline: -1rem;
+      padding-inline: 1rem;
+      padding-bottom: 0.25rem;
+    }
+    .branchview {
+      width: 820px;
+      min-width: 820px;
+    }
+    .branchview-figure::after {
+      content: '↔ карта шире экрана — листай горизонтально';
+      display: block;
+      text-align: center;
+      font-size: 0.78rem;
+      color: var(--sl-color-gray-3);
+      margin-top: 0.5rem;
+      padding-inline: 1rem;
+    }
+  }
+
   .branchview .edge {
     stroke: var(--sl-color-gray-4);
     stroke-width: 1.6;

--- a/src/components/Spider.astro
+++ b/src/components/Spider.astro
@@ -286,6 +286,35 @@ const viewBoxH = totalHeight;
   }
 
   /*
+   * Мобильный режим: ниже 900px SVG сжимается так, что текст становится
+   * нечитаем (~5pt). Делаем контейнер горизонтально скроллируемым,
+   * SVG получает фиксированную min-width и масштабируется по высоте.
+   * Снизу — подсказка «↔ листай горизонтально», скрывается на десктопе.
+   */
+  @media (max-width: 900px) {
+    .spider-figure {
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      margin-inline: -1rem; /* визуально вытягиваем под полные поля */
+      padding-inline: 1rem;
+      padding-bottom: 0.25rem;
+    }
+    .spider {
+      width: 960px;
+      min-width: 960px;
+    }
+    .spider-figure::after {
+      content: '↔ карта шире экрана — листай горизонтально';
+      display: block;
+      text-align: center;
+      font-size: 0.78rem;
+      color: var(--sl-color-gray-3);
+      margin-top: 0.5rem;
+      padding-inline: 1rem;
+    }
+  }
+
+  /*
    * Палитра по ветвям. Каждая ветка задаёт свой акцентный цвет (--bc)
    * и его «низкую» версию (--bc-low). Дальше стили узлов читают эти
    * переменные через data-branch, и одно правило раскрашивает три ветки.

--- a/src/components/Spider.astro
+++ b/src/components/Spider.astro
@@ -34,6 +34,19 @@ function estimateWidth(label: string, charW: number): number {
   return Math.max(MIN_NODE_W, Math.round(label.length * charW) + NODE_PAD_X);
 }
 
+// Lucide-style иконки 24×24, stroke-based. Используются на branch-узлах.
+const BRANCH_ICONS: Record<string, string> = {
+  // users — про людей и команды (Culture)
+  culture:
+    'M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2 M9 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8 M22 21v-2a4 4 0 0 0-3-3.87 M16 3.13a4 4 0 0 1 0 7.75',
+  // server — про инфраструктуру и код (Engineering)
+  engineering:
+    'M2 4h20v6H2z M2 14h20v6H2z M6 7h.01 M6 17h.01',
+  // clipboard-check — про процессы и ритуалы (Practices)
+  practices:
+    'M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2 M9 3h6v4H9z M9 14l2 2 4-4',
+};
+
 interface Node {
   kind: 'root' | 'branch' | 'l1' | 'leaf';
   branchId?: string;
@@ -58,11 +71,16 @@ const edges: Edge[] = [];
 
 // Per-column widths — растягиваем колонку под самый длинный label,
 // чтобы все узлы в колонке были одной ширины (выравнивание сохраняется).
+// Branch-колонка дополнительно резервирует место под иконку.
+const BRANCH_ICON_W = 20;
+const BRANCH_ICON_GAP = 10;
 let branchColW = MIN_NODE_W;
 let l1ColW = MIN_NODE_W;
 let leafColW = MIN_NODE_W;
 for (const branch of roadmap.branches) {
-  branchColW = Math.max(branchColW, estimateWidth(branch.label, CHAR_W_BRANCH));
+  const branchEstimate =
+    estimateWidth(branch.label, CHAR_W_BRANCH) + BRANCH_ICON_W + BRANCH_ICON_GAP;
+  branchColW = Math.max(branchColW, branchEstimate);
   for (const l1 of branch.l1) {
     l1ColW = Math.max(l1ColW, estimateWidth(l1.label, CHAR_W_L1));
     for (const leaf of l1.leaves ?? []) {
@@ -216,15 +234,39 @@ const viewBoxH = totalHeight;
       const cy = n.y + n.height / 2 + 5;
       const rx = n.kind === 'root' ? n.height / 2 : 6;
       const groupFilter = n.kind === 'root' ? 'url(#spider-root-glow)' : undefined;
+      const iconPath = n.kind === 'branch' && n.branchId ? BRANCH_ICONS[n.branchId] : undefined;
+      // Когда есть иконка — рисуем «иконка + текст» как единый блок,
+      // центрированный внутри rect. Иначе — обычный центрированный текст.
+      let textX = cx;
+      let textAnchor: 'middle' | 'start' = 'middle';
+      let iconX = 0;
+      let iconY = 0;
+      if (iconPath) {
+        const estTextW = Math.round(n.label.length * CHAR_W_BRANCH);
+        const totalW = BRANCH_ICON_W + BRANCH_ICON_GAP + estTextW;
+        const contentLeft = n.x + (n.width - totalW) / 2;
+        iconX = contentLeft;
+        iconY = n.y + (n.height - BRANCH_ICON_W) / 2;
+        textX = contentLeft + BRANCH_ICON_W + BRANCH_ICON_GAP;
+        textAnchor = 'start';
+      }
       return (
         <g class={`node node-${n.kind}`} data-branch={n.branchId} filter={groupFilter}>
           <rect x={n.x} y={n.y} width={n.width} height={n.height} rx={rx} ry={rx} />
+          {iconPath && (
+            <g
+              class="branch-icon"
+              transform={`translate(${iconX}, ${iconY}) scale(${BRANCH_ICON_W / 24})`}
+            >
+              <path d={iconPath} />
+            </g>
+          )}
           {n.href ? (
             <a href={link(n.href)}>
-              <text x={cx} y={cy} text-anchor="middle">{n.label}</text>
+              <text x={textX} y={cy} text-anchor={textAnchor}>{n.label}</text>
             </a>
           ) : (
-            <text x={cx} y={cy} text-anchor="middle">{n.label}</text>
+            <text x={textX} y={cy} text-anchor={textAnchor}>{n.label}</text>
           )}
         </g>
       );
@@ -334,6 +376,15 @@ const viewBoxH = totalHeight;
     font-weight: 700;
     font-size: 15px;
     letter-spacing: 0.02em;
+  }
+
+  /* Иконка ветки — белый stroke, lucide-style */
+  .spider .branch-icon path {
+    fill: none;
+    stroke: #fff;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
   }
 
   /* L1 — рамка цвета ветки, светлый фон */

--- a/src/components/Spider.astro
+++ b/src/components/Spider.astro
@@ -49,6 +49,7 @@ interface Edge {
   y1: number;
   x2: number;
   y2: number;
+  branchId?: string;
 }
 
 const nodes: Node[] = [];
@@ -121,6 +122,7 @@ for (const [bi, branch] of roadmap.branches.entries()) {
     y1: rootY,
     x2: BRANCH_X,
     y2: branchCenters[bi],
+    branchId: branch.id,
   });
   nodes.push({
     kind: 'branch',
@@ -139,6 +141,7 @@ for (const [bi, branch] of roadmap.branches.entries()) {
       y1: branchCenters[bi],
       x2: L1_X,
       y2: l1Centers[bi][l1i],
+      branchId: branch.id,
     });
     nodes.push({
       kind: 'l1',
@@ -158,6 +161,7 @@ for (const [bi, branch] of roadmap.branches.entries()) {
         y1: l1Centers[bi][l1i],
         x2: LEAF_X,
         y2: leafY,
+        branchId: branch.id,
       });
       nodes.push({
         kind: 'leaf',
@@ -186,7 +190,14 @@ const viewBoxH = totalHeight;
     aria-label="Карта компетенций SRE — кликабельный паучок"
   >
     {edges.map((e) => (
-      <line class="edge" x1={e.x1} y1={e.y1} x2={e.x2} y2={e.y2} />
+      <line
+        class="edge"
+        data-branch={e.branchId}
+        x1={e.x1}
+        y1={e.y1}
+        x2={e.x2}
+        y2={e.y2}
+      />
     ))}
 
     {nodes.map((n) => {
@@ -194,7 +205,7 @@ const viewBoxH = totalHeight;
       const cy = n.y + n.height / 2 + 5;
       const rx = n.kind === 'root' ? n.height / 2 : 6;
       return (
-        <g class={`node node-${n.kind}`}>
+        <g class={`node node-${n.kind}`} data-branch={n.branchId}>
           <rect x={n.x} y={n.y} width={n.width} height={n.height} rx={rx} ry={rx} />
           {n.href ? (
             <a href={link(n.href)}>
@@ -220,11 +231,58 @@ const viewBoxH = totalHeight;
     display: block;
   }
 
-  .spider .edge {
-    stroke: var(--sl-color-gray-4);
-    stroke-width: 1.5;
+  /*
+   * Палитра по ветвям. Каждая ветка задаёт свой акцентный цвет (--bc)
+   * и его «низкую» версию (--bc-low). Дальше стили узлов читают эти
+   * переменные через data-branch, и одно правило раскрашивает три ветки.
+   *
+   * Light-тема: насыщенные средние оттенки (контраст к белому фону).
+   * Dark-тема: чуть осветлённые (контраст к тёмному фону).
+   */
+  .spider [data-branch='culture'] {
+    --bc: #d97706; /* amber-600 — про людей и нормы, тёплый */
+    --bc-low: #fef3c7; /* amber-100 */
+    --bc-text: #78350f; /* amber-900 */
+  }
+  .spider [data-branch='engineering'] {
+    --bc: #0d9488; /* teal-600 — про железо и код, холодный */
+    --bc-low: #ccfbf1; /* teal-100 */
+    --bc-text: #134e4a; /* teal-900 */
+  }
+  .spider [data-branch='practices'] {
+    --bc: #6366f1; /* indigo-500 — про процессы, нейтральный фиолетовый */
+    --bc-low: #e0e7ff; /* indigo-100 */
+    --bc-text: #312e81; /* indigo-900 */
+  }
+  :root[data-theme='dark'] .spider [data-branch='culture'] {
+    --bc: #f59e0b; /* amber-500 */
+    --bc-low: #44301a; /* deep amber tint */
+    --bc-text: #fde68a; /* amber-200 */
+  }
+  :root[data-theme='dark'] .spider [data-branch='engineering'] {
+    --bc: #2dd4bf; /* teal-400 */
+    --bc-low: #133b37; /* deep teal tint */
+    --bc-text: #99f6e4; /* teal-200 */
+  }
+  :root[data-theme='dark'] .spider [data-branch='practices'] {
+    --bc: #818cf8; /* indigo-400 */
+    --bc-low: #1f1f4e; /* deep indigo tint */
+    --bc-text: #c7d2fe; /* indigo-200 */
   }
 
+  /* Edges — fallback серый, окрашенные перебивают */
+  .spider .edge {
+    stroke: var(--sl-color-gray-4);
+    stroke-width: 1.6;
+    opacity: 0.85;
+  }
+  .spider .edge[data-branch] {
+    stroke: var(--bc);
+    stroke-width: 2;
+    opacity: 0.55;
+  }
+
+  /* Base node — для root и fallback */
   .spider .node rect {
     fill: var(--sl-color-bg-nav);
     stroke: var(--sl-color-gray-4);
@@ -240,11 +298,11 @@ const viewBoxH = totalHeight;
     user-select: none;
   }
 
+  /* Root */
   .spider .node-root rect {
     fill: var(--sl-color-accent);
     stroke: var(--sl-color-accent);
   }
-
   .spider .node-root text {
     fill: var(--sl-color-white);
     font-weight: 700;
@@ -252,15 +310,33 @@ const viewBoxH = totalHeight;
     letter-spacing: 0.05em;
   }
 
-  .spider .node-branch text {
-    font-weight: 600;
+  /* Branch — фон цвета ветки, белый текст */
+  .spider .node-branch[data-branch] rect {
+    fill: var(--bc);
+    stroke: var(--bc);
+  }
+  .spider .node-branch[data-branch] text {
+    fill: #fff;
+    font-weight: 700;
     font-size: 14px;
   }
 
-  .spider .node-leaf rect {
-    fill: var(--sl-color-accent-low);
-    stroke: var(--sl-color-accent);
-    stroke-width: 2;
+  /* L1 — рамка цвета ветки, светлый фон */
+  .spider .node-l1[data-branch] rect {
+    fill: var(--sl-color-bg);
+    stroke: var(--bc);
+    stroke-width: 1.5;
+  }
+
+  /* Leaf — приглушённая заливка цвета ветки + цветной текст */
+  .spider .node-leaf[data-branch] rect {
+    fill: var(--bc-low);
+    stroke: var(--bc);
+    stroke-width: 1.8;
+  }
+  .spider .node-leaf[data-branch] text {
+    fill: var(--bc-text);
+    font-weight: 600;
   }
 
   .spider a {
@@ -273,7 +349,6 @@ const viewBoxH = totalHeight;
 
   .spider a:hover text,
   .spider a:focus text {
-    fill: var(--sl-color-accent-high);
     text-decoration: underline;
     text-decoration-thickness: 2px;
   }

--- a/src/components/Spider.astro
+++ b/src/components/Spider.astro
@@ -16,17 +16,26 @@ const link = (path: string) => `${base}${path}`;
 const ROW_H = 34;
 const BRANCH_GAP = 22;
 const ROOT_X = 60;
-const BRANCH_X = 260;
-const L1_X = 540;
-const LEAF_X = 820;
-const NODE_W = 220;
+const COLUMN_GAP = 60;
+const MIN_NODE_W = 180;
 const NODE_H = 28;
+const NODE_PAD_X = 28; // padding inside the rect (left+right combined)
 const ROOT_W = 110;
 const ROOT_H = 56;
 const TOP_PAD = 24;
+// Approximate char widths in px at our font-size (13px, weight 500/600).
+// Estimates are conservative so wide glyphs (W/M/—) don't clip.
+const CHAR_W_BRANCH = 8.2; // 14px / 600
+const CHAR_W_L1 = 7.4; // 13px / 500
+const CHAR_W_LEAF = 7.4;
+
+function estimateWidth(label: string, charW: number): number {
+  return Math.max(MIN_NODE_W, Math.round(label.length * charW) + NODE_PAD_X);
+}
 
 interface Node {
   kind: 'root' | 'branch' | 'l1' | 'leaf';
+  branchId?: string;
   label: string;
   x: number;
   y: number;
@@ -44,6 +53,25 @@ interface Edge {
 
 const nodes: Node[] = [];
 const edges: Edge[] = [];
+
+// Per-column widths — растягиваем колонку под самый длинный label,
+// чтобы все узлы в колонке были одной ширины (выравнивание сохраняется).
+let branchColW = MIN_NODE_W;
+let l1ColW = MIN_NODE_W;
+let leafColW = MIN_NODE_W;
+for (const branch of roadmap.branches) {
+  branchColW = Math.max(branchColW, estimateWidth(branch.label, CHAR_W_BRANCH));
+  for (const l1 of branch.l1) {
+    l1ColW = Math.max(l1ColW, estimateWidth(l1.label, CHAR_W_L1));
+    for (const leaf of l1.leaves ?? []) {
+      leafColW = Math.max(leafColW, estimateWidth(leaf.label, CHAR_W_LEAF));
+    }
+  }
+}
+
+const BRANCH_X = ROOT_X + ROOT_W + COLUMN_GAP;
+const L1_X = BRANCH_X + branchColW + COLUMN_GAP;
+const LEAF_X = L1_X + l1ColW + COLUMN_GAP;
 
 // Compute Y positions: leaves drive vertical layout — каждый leaf занимает свою
 // строку, L1 центрируется между своими leaves, ветвь центрируется между L1.
@@ -96,27 +124,29 @@ for (const [bi, branch] of roadmap.branches.entries()) {
   });
   nodes.push({
     kind: 'branch',
+    branchId: branch.id,
     label: branch.label,
     x: BRANCH_X,
     y: branchCenters[bi] - NODE_H / 2,
-    width: NODE_W,
+    width: branchColW,
     height: NODE_H,
     href: branch.href,
   });
 
   for (const [l1i, l1] of branch.l1.entries()) {
     edges.push({
-      x1: BRANCH_X + NODE_W,
+      x1: BRANCH_X + branchColW,
       y1: branchCenters[bi],
       x2: L1_X,
       y2: l1Centers[bi][l1i],
     });
     nodes.push({
       kind: 'l1',
+      branchId: branch.id,
       label: l1.label,
       x: L1_X,
       y: l1Centers[bi][l1i] - NODE_H / 2,
-      width: NODE_W,
+      width: l1ColW,
       height: NODE_H,
       href: `${branch.href}#${l1.id}`,
     });
@@ -124,17 +154,18 @@ for (const [bi, branch] of roadmap.branches.entries()) {
     for (const [leafI, leaf] of (l1.leaves ?? []).entries()) {
       const leafY = leafCenters[bi][l1i][leafI];
       edges.push({
-        x1: L1_X + NODE_W,
+        x1: L1_X + l1ColW,
         y1: l1Centers[bi][l1i],
         x2: LEAF_X,
         y2: leafY,
       });
       nodes.push({
         kind: 'leaf',
+        branchId: branch.id,
         label: leaf.label,
         x: LEAF_X,
         y: leafY - NODE_H / 2,
-        width: NODE_W,
+        width: leafColW,
         height: NODE_H,
         href: leaf.href,
       });
@@ -142,7 +173,7 @@ for (const [bi, branch] of roadmap.branches.entries()) {
   }
 }
 
-const viewBoxW = LEAF_X + NODE_W + 20;
+const viewBoxW = LEAF_X + leafColW + 20;
 const viewBoxH = totalHeight;
 ---
 

--- a/src/components/Spider.astro
+++ b/src/components/Spider.astro
@@ -14,15 +14,16 @@ const link = (path: string) => `${base}${path}`;
 
 // Layout constants
 const ROW_H = 34;
-const BRANCH_GAP = 22;
+const BRANCH_GAP = 26;
 const ROOT_X = 60;
 const COLUMN_GAP = 60;
 const MIN_NODE_W = 180;
-const NODE_H = 28;
-const NODE_PAD_X = 28; // padding inside the rect (left+right combined)
-const ROOT_W = 110;
-const ROOT_H = 56;
-const TOP_PAD = 24;
+const NODE_H = 28; // L1 / leaf height
+const BRANCH_H = 40; // branch-узлы крупнее — они «опорные»
+const NODE_PAD_X = 28;
+const ROOT_W = 150; // root заметно крупнее, доминирует визуально
+const ROOT_H = 84;
+const TOP_PAD = 32;
 // Approximate char widths in px at our font-size (13px, weight 500/600).
 // Estimates are conservative so wide glyphs (W/M/—) don't clip.
 const CHAR_W_BRANCH = 8.2; // 14px / 600
@@ -129,9 +130,9 @@ for (const [bi, branch] of roadmap.branches.entries()) {
     branchId: branch.id,
     label: branch.label,
     x: BRANCH_X,
-    y: branchCenters[bi] - NODE_H / 2,
+    y: branchCenters[bi] - BRANCH_H / 2,
     width: branchColW,
-    height: NODE_H,
+    height: BRANCH_H,
     href: branch.href,
   });
 
@@ -189,6 +190,16 @@ const viewBoxH = totalHeight;
     role="img"
     aria-label="Карта компетенций SRE — кликабельный паучок"
   >
+    <defs>
+      {/* Лёгкое свечение под root — root «семя» карты, должен доминировать. */}
+      <filter id="spider-root-glow" x="-50%" y="-50%" width="200%" height="200%">
+        <feGaussianBlur in="SourceGraphic" stdDeviation="4" result="blur" />
+        <feMerge>
+          <feMergeNode in="blur" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+    </defs>
     {edges.map((e) => (
       <line
         class="edge"
@@ -204,8 +215,9 @@ const viewBoxH = totalHeight;
       const cx = n.x + n.width / 2;
       const cy = n.y + n.height / 2 + 5;
       const rx = n.kind === 'root' ? n.height / 2 : 6;
+      const groupFilter = n.kind === 'root' ? 'url(#spider-root-glow)' : undefined;
       return (
-        <g class={`node node-${n.kind}`} data-branch={n.branchId}>
+        <g class={`node node-${n.kind}`} data-branch={n.branchId} filter={groupFilter}>
           <rect x={n.x} y={n.y} width={n.width} height={n.height} rx={rx} ry={rx} />
           {n.href ? (
             <a href={link(n.href)}>
@@ -298,27 +310,30 @@ const viewBoxH = totalHeight;
     user-select: none;
   }
 
-  /* Root */
+  /* Root — «семя» карты, доминанта */
   .spider .node-root rect {
     fill: var(--sl-color-accent);
     stroke: var(--sl-color-accent);
+    stroke-width: 2;
   }
   .spider .node-root text {
     fill: var(--sl-color-white);
-    font-weight: 700;
-    font-size: 18px;
-    letter-spacing: 0.05em;
+    font-weight: 800;
+    font-size: 24px;
+    letter-spacing: 0.06em;
   }
 
-  /* Branch — фон цвета ветки, белый текст */
+  /* Branch — крупнее L1, фон цвета ветки */
   .spider .node-branch[data-branch] rect {
     fill: var(--bc);
     stroke: var(--bc);
+    stroke-width: 2;
   }
   .spider .node-branch[data-branch] text {
     fill: #fff;
     font-weight: 700;
-    font-size: 14px;
+    font-size: 15px;
+    letter-spacing: 0.02em;
   }
 
   /* L1 — рамка цвета ветки, светлый фон */

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -3,9 +3,61 @@ title: The Way of SRE
 description: Карта компетенций для развития в роли Site Reliability Engineer
 template: splash
 hero:
-  tagline: Карта направлений в SRE с конкретными умениями, материалами и best practices в каждом листе.
+  tagline: Карта направлений в SRE — три ветви, 20 компетенций верхнего уровня, листья с конкретными умениями, материалами и best practices.
+  actions:
+    - text: Roadmap по приоритетам
+      link: /priorities/
+      icon: right-arrow
+      variant: primary
+    - text: GitHub
+      link: https://github.com/jtprogru/The-Way-of-SRE
+      icon: external
+      variant: minimal
 ---
 
+import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 import Spider from '../../components/Spider.astro';
+import { roadmap } from '../../data/roadmap.ts';
+
+export const totalLeaves = roadmap.branches.reduce(
+  (sum, b) => sum + b.l1.reduce((s, l1) => s + (l1.leaves?.length ?? 0), 0),
+  0,
+);
+export const totalL1 = roadmap.branches.reduce((sum, b) => sum + b.l1.length, 0);
+
+<p class="intro-blurb">
+  Зачем это нужно: SRE — широкая область на стыке разработки, инфраструктуры и
+  процессов. Эта карта показывает, что входит в роль и в какой последовательности
+  разумно развиваться. Каждый лист — отдельная практика с материалами,
+  external references и SFIA-уровнями для самооценки.
+</p>
+
+<CardGrid>
+  <LinkCard
+    title="SRE Culture"
+    description="Люди, нормы, обмен опытом. Партнёрство с командами, постмортем-культура, метрики надёжности как инструмент разговора."
+    href="/sre-culture/"
+  />
+  <LinkCard
+    title="SRE Engineering"
+    description="Технические компетенции. Observability, SLO, networking, IaC, capacity planning, database reliability."
+    href="/sre-engineering/"
+  />
+  <LinkCard
+    title="SRE Practices"
+    description="Процессы и ритуалы. Incident management, change management, on-call, security, профессиональное развитие."
+    href="/sre-practices/"
+  />
+</CardGrid>
+
+<p class="meta-strip">
+  <span><strong>3</strong> ветви</span>
+  <span aria-hidden="true">·</span>
+  <span><strong>{totalL1}</strong> компетенций верхнего уровня</span>
+  <span aria-hidden="true">·</span>
+  <span><strong>{totalLeaves}</strong> листьев полной глубины</span>
+  <span aria-hidden="true">·</span>
+  <span>open source · Apache-2.0</span>
+</p>
 
 <Spider />

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -91,3 +91,35 @@ body:has(.hero) {
 .meta-strip > span[aria-hidden='true'] {
   opacity: 0.5;
 }
+
+/*
+ * Pillar-карточки на главной — тонируем в палитру их ветки.
+ * Согласованность с Spider: Culture amber, Engineering teal, Practices indigo.
+ * Цвет проявляется как левый borderr и переход на hover.
+ */
+.sl-link-card:has(a[href*='/sre-culture']) {
+  border-inline-start: 4px solid #d97706;
+}
+.sl-link-card:has(a[href*='/sre-engineering']) {
+  border-inline-start: 4px solid #0d9488;
+}
+.sl-link-card:has(a[href*='/sre-practices']) {
+  border-inline-start: 4px solid #6366f1;
+}
+
+:root[data-theme='dark'] .sl-link-card:has(a[href*='/sre-culture']) {
+  border-inline-start-color: #f59e0b;
+}
+:root[data-theme='dark'] .sl-link-card:has(a[href*='/sre-engineering']) {
+  border-inline-start-color: #2dd4bf;
+}
+:root[data-theme='dark'] .sl-link-card:has(a[href*='/sre-practices']) {
+  border-inline-start-color: #818cf8;
+}
+
+.sl-link-card:has(a[href*='/sre-culture']):hover,
+.sl-link-card:has(a[href*='/sre-engineering']):hover,
+.sl-link-card:has(a[href*='/sre-practices']):hover {
+  transform: translateY(-2px);
+  transition: transform 0.15s ease;
+}

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -34,3 +34,39 @@
 .hero .tagline {
   max-width: none !important;
 }
+
+/* Intro-blurb на главной — короткий «зачем это нужно» между hero и карточками */
+.intro-blurb {
+  max-width: 64ch;
+  margin: 1.5rem auto 2.5rem;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--sl-color-gray-2);
+  text-align: center;
+}
+
+/* Meta-strip: счётчики и open source метка */
+.meta-strip {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem 1rem;
+  margin: 2rem auto 1rem;
+  font-size: 0.9rem;
+  color: var(--sl-color-gray-3);
+  text-align: center;
+}
+
+.meta-strip strong {
+  color: var(--sl-color-white);
+  font-weight: 700;
+}
+
+:root[data-theme='light'] .meta-strip strong {
+  color: var(--sl-color-text);
+}
+
+.meta-strip > span[aria-hidden='true'] {
+  opacity: 0.5;
+}

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -4,12 +4,33 @@
   --sl-color-accent-low: #1e3a5f;
   --sl-color-accent: #4a90d9;
   --sl-color-accent-high: #b3d3f2;
+  /* dot-grid палитра — еле заметные точки, читается «как-будто схема» */
+  --dot-color: rgba(255, 255, 255, 0.05);
 }
 
 :root[data-theme='light'] {
   --sl-color-accent-low: #d6e7f7;
   --sl-color-accent: #2563eb;
   --sl-color-accent-high: #0b3d91;
+  --dot-color: rgba(0, 0, 0, 0.06);
+  /* off-white фон вместо стерильно-белого */
+  --sl-color-bg: #fafaf7;
+}
+
+/*
+ * Dot-grid подложка под splash-страницей. Активируется только на
+ * страницах с template: splash (детект через :has(.hero)). Не трогает
+ * остальной сайт — там обычные документные страницы и сетка отвлекает.
+ */
+body:has(.hero) {
+  background-image: radial-gradient(
+    circle,
+    var(--dot-color) 1px,
+    transparent 1px
+  );
+  background-size: 24px 24px;
+  background-position: 0 0;
+  background-attachment: fixed;
 }
 
 /*


### PR DESCRIPTION
## Контекст

Внешняя ревизия визуала landing-страницы. Замечания касались семи зон — от критичных багов (текст вылезает за рамку, мобильная версия нечитаема) до полировки (типографика, фон, иконки). Этот PR закрывает все приоритетные пункты в восьми атомарных коммитах.

## Что меняется

### Критичные фиксы

- **fix(spider): auto-fit node width** — длинные L1-надписи («Organisational Capability Development») вылезали за рамку фиксированного `NODE_W=220`. Теперь ширина колонки рассчитывается по самому длинному label с `MIN_NODE_W=180`, `X`-координаты колонок — от ширины предыдущей колонки + `COLUMN_GAP`.
- **feat: мобильный fallback** — ниже 900px SVG превращался в нечитаемую кляксу. Теперь контейнер `overflow-x: auto`, SVG получает фиксированную `min-width`, снизу — подсказка «↔ карта шире экрана».

### Большие визуальные изменения

- **feat: цветовое кодирование по ветвям** — Culture amber, Engineering teal, Practices indigo. Применяется к branch-узлу (фон), L1-узлам (рамка), leaf-узлам (фон + цветной текст) и линиям связи. Палитра через CSS-переменные `--bc/--bc-low/--bc-text` на `data-branch`-атрибуте, одно правило на три ветки, полная light/dark адаптация.
- **feat: иерархическая визуализация** — root узел вырос с 110×56 до 150×84 (текст 18px → 24px / 700 → 800), плюс мягкое свечение через SVG `feGaussianBlur`-filter. Branch-узлы — 40px высота вместо 28, чуть жирнее. L1/leaf без изменений — иерархия теперь читается с одного взгляда.
- **feat: иконки на пиллерах (lucide-style)** — users / server / clipboard-check inline SVG-paths слева от каждого branch-узла. Branch-колонка резервирует дополнительные 30px на иконку, текст и иконка центрируются как единый блок.

### Hero и landing

- **feat: обогащённый hero** — `hero.actions` (Roadmap по приоритетам + GitHub), intro-blurb «зачем это нужно», `CardGrid` с тремя `LinkCard` на пиллеры (быстрая навигация без скролла), meta-strip (счётчики веток / L1 / листьев из `roadmap.ts` на этапе билда).
- **feat: tinted pillar-карточки** — каждая карточка получает левый border в цвете своей ветки, визуально связывая её со Spider-картой.

### Фон и тема

- **feat: dot-grid + off-white** — splash-страница (детект через `body:has(.hero)`) получает едва заметную dot-grid подложку как fixed background. Светлая тема: фон `#fafaf7` вместо стерильного `#fff`.

## Что не вошло (намеренно)

- **Кастомная типографика** (Space Grotesk/Inter Display) — загрузка шрифтов фрагильна, отложено до явного запроса.
- **Логотип-марк в навбаре** — требует фактического дизайна бренда, выходит за рамки.
- **Vertical accordion на мобайле** — требует дублирующего рендера данных, текущий горизонтальный скролл консервативнее.
- **Компактный поиск в навбаре** — Starlight integration, фрагильно между версиями.

## Test plan

- [ ] `npm run build` проходит без ошибок (✅ проверено локально, 32 страницы)
- [ ] Главная: hero с actions, intro, 3 карточки, meta-strip, Spider ниже
- [ ] Spider: длинные надписи не вылезают за рамку
- [ ] Spider: каждая ветка в своей палитре (amber/teal/indigo)
- [ ] Spider: root заметно крупнее остальных узлов, с лёгким свечением
- [ ] Spider: иконки рядом с branch-надписями
- [ ] Branch-страницы (`/sre-*`): та же палитра, что и на главной
- [ ] Priority-страница: цвета приоритетов **не** перебиты (оставлены как есть, у них своя семантика)
- [ ] Мобайл (≤ 900px): горизонтальный скролл с подсказкой
- [ ] Light/dark переключаются корректно во всех режимах