### PR TITLE
fix(index): base-префикс для hero action и pillar-карточек

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: Карта направлений в SRE — три ветви, 20 компетенций верхнего уровня, листья с конкретными умениями, материалами и best practices.
   actions:
     - text: Roadmap по приоритетам
-      link: /priorities/
+      link: /The-Way-of-SRE/priorities/
       icon: right-arrow
       variant: primary
     - text: GitHub
@@ -19,6 +19,7 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 import Spider from '../../components/Spider.astro';
 import { roadmap } from '../../data/roadmap.ts';
 
+export const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 export const totalLeaves = roadmap.branches.reduce(
   (sum, b) => sum + b.l1.reduce((s, l1) => s + (l1.leaves?.length ?? 0), 0),
   0,
@@ -36,17 +37,17 @@ export const totalL1 = roadmap.branches.reduce((sum, b) => sum + b.l1.length, 0)
   <LinkCard
     title="SRE Culture"
     description="Люди, нормы, обмен опытом. Партнёрство с командами, постмортем-культура, метрики надёжности как инструмент разговора."
-    href="/sre-culture/"
+    href={`${base}/sre-culture/`}
   />
   <LinkCard
     title="SRE Engineering"
     description="Технические компетенции. Observability, SLO, networking, IaC, capacity planning, database reliability."
-    href="/sre-engineering/"
+    href={`${base}/sre-engineering/`}
   />
   <LinkCard
     title="SRE Practices"
     description="Процессы и ритуалы. Incident management, change management, on-call, security, профессиональное развитие."
-    href="/sre-practices/"
+    href={`${base}/sre-practices/`}
   />
 </CardGrid>
 


### PR DESCRIPTION
## Проблема

После PR #44 на главной странице **четыре ссылки выдают 404** на проде:

- Hero-action «Roadmap по приоритетам» → `/priorities/` (должно быть `/The-Way-of-SRE/priorities/`)
- Pillar-карточки «SRE Culture / Engineering / Practices» → `/sre-{culture,engineering,practices}/`

В \`astro.config.mjs\` стоит \`base: '/The-Way-of-SRE'\`. Starlight автоматически префиксит base только в **своих** sidebar/nav, но не трогает:
- \`hero.actions[].link\` в frontmatter
- \`<LinkCard href=\"...\" />\` (это просто JSX-компонент)

В результате генерировался HTML с \`href=\"/priorities/\"\` — на GitHub Pages это уходит на \`https://jtprogru.github.io/priorities/\` → 404.

## Исправление

- \`hero.actions[0].link\` — захардкожено как \`/The-Way-of-SRE/priorities/\`. YAML-фронт-маттер не выполняет выражения, и это согласовано с конвенцией в \`priorities.mdx\` (там аналогично \`/The-Way-of-SRE/sre-culture/#...\`).
- \`LinkCard href\` — через \`export const base = import.meta.env.BASE_URL.replace(/\/$/, '')\` и шаблонные строки. Идиоматично, переживает изменение base.

## Test plan

- [x] \`npm run build\` — 32 страницы, без ошибок.
- [x] В \`dist/index.html\` все \`href\` к pillar-страницам и /priorities/ теперь с префиксом \`/The-Way-of-SRE/\`; «голых» \`href=\"/priorities/\"\` / \`href=\"/sre-culture/\"\` не осталось.
- [ ] После мержа — проверить, что прод-страница на GitHub Pages открывает каждую из четырёх ссылок (200, не 404).