### PR TITLE
fix(priorities): согласовать паучки и убрать устаревший L2-контент

### DIFF
--- a/src/components/BranchView.astro
+++ b/src/components/BranchView.astro
@@ -10,6 +10,7 @@
 //     priority   — L1-узлы окрашены в соответствии с приоритетом
 
 import { getBranch, priorityLabels, type Priority } from '../data/roadmap.ts';
+import { BRANCH_ICONS, BRANCH_ICON_W, BRANCH_ICON_GAP } from '../data/branchIcons.ts';
 
 interface Props {
   branchId: 'culture' | 'engineering' | 'practices';
@@ -42,7 +43,13 @@ function estimateWidth(label: string, charW: number): number {
   return Math.max(MIN_NODE_W, Math.round(label.length * charW) + NODE_PAD_X);
 }
 
-const branchColW = estimateWidth(branch.label, CHAR_W_BRANCH);
+// В priority варианте на branch-узле есть иконка — резервируем под неё
+// дополнительно ширину (так же, как в Spider.astro). В navigation варианте
+// иконки нет, чтобы не дублировать смысл «карты ветви» — там это лишний шум.
+const branchHasIcon = variant === 'priority';
+const branchColW =
+  estimateWidth(branch.label, CHAR_W_BRANCH) +
+  (branchHasIcon ? BRANCH_ICON_W + BRANCH_ICON_GAP : 0);
 let l1ColW = MIN_NODE_W;
 let leafColW = MIN_NODE_W;
 for (const l1 of branch.l1) {
@@ -86,7 +93,7 @@ for (const _ of branch.l1) {
 const totalHeight = cursorY + TOP_PAD;
 const branchCenter = (l1Centers[0] + l1Centers[l1Centers.length - 1]) / 2;
 
-// Branch node
+// Branch node — кликабельный, как в Spider.astro.
 nodes.push({
   kind: 'branch',
   priority: branch.priority,
@@ -95,6 +102,7 @@ nodes.push({
   y: branchCenter - NODE_H / 2,
   width: branchColW,
   height: NODE_H,
+  href: branch.href,
 });
 
 // L1s + leaves
@@ -157,15 +165,39 @@ const viewBoxH = totalHeight;
       const cy = n.y + n.height / 2 + 5;
       const priorityClass =
         variant === 'priority' && n.priority ? `priority-${n.priority}` : '';
+      const iconPath =
+        n.kind === 'branch' && branchHasIcon ? BRANCH_ICONS[branch.id] : undefined;
+      // С иконкой текст и иконка центрируются как единый блок (см. Spider.astro).
+      let textX = cx;
+      let textAnchor: 'middle' | 'start' = 'middle';
+      let iconX = 0;
+      let iconY = 0;
+      if (iconPath) {
+        const estTextW = Math.round(n.label.length * CHAR_W_BRANCH);
+        const totalW = BRANCH_ICON_W + BRANCH_ICON_GAP + estTextW;
+        const contentLeft = n.x + (n.width - totalW) / 2;
+        iconX = contentLeft;
+        iconY = n.y + (n.height - BRANCH_ICON_W) / 2;
+        textX = contentLeft + BRANCH_ICON_W + BRANCH_ICON_GAP;
+        textAnchor = 'start';
+      }
       return (
         <g class={`node node-${n.kind} ${priorityClass}`}>
           <rect x={n.x} y={n.y} width={n.width} height={n.height} rx="6" ry="6" />
+          {iconPath && (
+            <g
+              class="branch-icon"
+              transform={`translate(${iconX}, ${iconY}) scale(${BRANCH_ICON_W / 24})`}
+            >
+              <path d={iconPath} />
+            </g>
+          )}
           {n.href ? (
             <a href={link(n.href)}>
-              <text x={cx} y={cy} text-anchor="middle">{n.label}</text>
+              <text x={textX} y={cy} text-anchor={textAnchor}>{n.label}</text>
             </a>
           ) : (
-            <text x={cx} y={cy} text-anchor="middle">{n.label}</text>
+            <text x={textX} y={cy} text-anchor={textAnchor}>{n.label}</text>
           )}
         </g>
       );
@@ -189,9 +221,10 @@ const viewBoxH = totalHeight;
 
   /*
    * Палитра по ветвям — соответствует Spider.astro (одна цветовая
-   * семантика на всех страницах). Применяется только в navigation-
-   * варианте; priority-вариант оставлен с собственной цветовой схемой
-   * через .priority-* классы (приоритеты — другая ось смысла).
+   * семантика на всех страницах). Применяется и в navigation-, и в
+   * priority-варианте — для branch-узла (чтобы согласоваться с главной).
+   * L1 и leaves в priority-варианте остаются в priority-цветах через
+   * .priority-* классы (приоритеты — отдельная ось смысла).
    */
   .branchview-figure[data-branch='culture'] {
     --bc: #d97706;
@@ -304,21 +337,26 @@ const viewBoxH = totalHeight;
     font-weight: 600;
   }
 
-  /* Priority variant: оставлен с исходной цветовой схемой (по приоритетам) */
+  /*
+   * Priority variant: branch-узел в канонической палитре ветви
+   * (согласовано с главной и navigation вариантом). L1 и leaves
+   * окрашиваются по приоритету через .priority-* классы ниже.
+   */
   .branchview-figure[data-variant='priority'] .node-branch rect {
-    fill: var(--sl-color-accent);
-    stroke: var(--sl-color-accent);
+    fill: var(--bc);
+    stroke: var(--bc);
   }
-
   .branchview-figure[data-variant='priority'] .node-branch text {
-    fill: var(--sl-color-white);
+    fill: #fff;
     font-weight: 700;
   }
-
-  .branchview-figure[data-variant='priority'] .node-leaf rect {
-    fill: var(--sl-color-accent-low);
-    stroke: var(--sl-color-accent);
-    stroke-width: 2;
+  /* Иконка ветви — белый stroke поверх заливки branch-цветом. */
+  .branchview .node-branch .branch-icon path {
+    fill: none;
+    stroke: #fff;
+    stroke-width: 1.8;
+    stroke-linecap: round;
+    stroke-linejoin: round;
   }
 
   /* Priority colors (variant=priority) */
@@ -358,12 +396,13 @@ const viewBoxH = totalHeight;
     stroke: #6ba8d9;
   }
 
-  /* Priority view: keep text color stable */
-  .branchview-figure[data-variant='priority'] .node-branch text,
+  /*
+   * Priority view: L1 text стабильно тёмный/светлый поверх priority-rect.
+   * Branch text определён выше — белый поверх branch-цвета.
+   */
   .branchview-figure[data-variant='priority'] .node-l1 text {
     fill: #222;
   }
-  :root[data-theme='dark'] .branchview-figure[data-variant='priority'] .node-branch text,
   :root[data-theme='dark'] .branchview-figure[data-variant='priority'] .node-l1 text {
     fill: var(--sl-color-text);
   }

--- a/src/components/BranchView.astro
+++ b/src/components/BranchView.astro
@@ -50,6 +50,13 @@ const branchHasIcon = variant === 'priority';
 const branchColW =
   estimateWidth(branch.label, CHAR_W_BRANCH) +
   (branchHasIcon ? BRANCH_ICON_W + BRANCH_ICON_GAP : 0);
+
+// В priority варианте listья не отображаем: страница про приоритет L1,
+// а leaves не имеют собственного priority (он наследуется от L1) —
+// одинаковые синие плашки только засоряют схему и не добавляют смысла.
+// На главной (Spider) listья видны со своими branch-tinted цветами;
+// на /sre-{branch}/ (navigation вариант) — тоже видны.
+const showLeaves = variant !== 'priority';
 let l1ColW = MIN_NODE_W;
 let leafColW = MIN_NODE_W;
 for (const l1 of branch.l1) {
@@ -124,26 +131,29 @@ for (const [l1i, l1] of branch.l1.entries()) {
     href: `${branch.href}#${l1.id}`,
   });
 
-  for (const leaf of l1.leaves ?? []) {
-    edges.push({
-      x1: L1_X + l1ColW,
-      y1: l1Centers[l1i],
-      x2: LEAF_X,
-      y2: l1Centers[l1i],
-    });
-    nodes.push({
-      kind: 'leaf',
-      label: leaf.label,
-      x: LEAF_X,
-      y: l1Centers[l1i] - NODE_H / 2,
-      width: leafColW,
-      height: NODE_H,
-      href: leaf.href,
-    });
+  if (showLeaves) {
+    for (const leaf of l1.leaves ?? []) {
+      edges.push({
+        x1: L1_X + l1ColW,
+        y1: l1Centers[l1i],
+        x2: LEAF_X,
+        y2: l1Centers[l1i],
+      });
+      nodes.push({
+        kind: 'leaf',
+        label: leaf.label,
+        x: LEAF_X,
+        y: l1Centers[l1i] - NODE_H / 2,
+        width: leafColW,
+        height: NODE_H,
+        href: leaf.href,
+      });
+    }
   }
 }
 
-const hasAnyLeaves = branch.l1.some((l1) => l1.leaves && l1.leaves.length > 0);
+const hasAnyLeaves =
+  showLeaves && branch.l1.some((l1) => l1.leaves && l1.leaves.length > 0);
 const viewBoxW = (hasAnyLeaves ? LEAF_X + leafColW : L1_X + l1ColW) + 20;
 const viewBoxH = totalHeight;
 ---

--- a/src/components/Spider.astro
+++ b/src/components/Spider.astro
@@ -8,6 +8,7 @@
 // Кликается ТОЛЬКО текст внутри узла, не сама фигура.
 
 import { roadmap } from '../data/roadmap.ts';
+import { BRANCH_ICONS, BRANCH_ICON_W, BRANCH_ICON_GAP } from '../data/branchIcons.ts';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const link = (path: string) => `${base}${path}`;
@@ -34,19 +35,6 @@ function estimateWidth(label: string, charW: number): number {
   return Math.max(MIN_NODE_W, Math.round(label.length * charW) + NODE_PAD_X);
 }
 
-// Lucide-style иконки 24×24, stroke-based. Используются на branch-узлах.
-const BRANCH_ICONS: Record<string, string> = {
-  // users — про людей и команды (Culture)
-  culture:
-    'M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2 M9 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8 M22 21v-2a4 4 0 0 0-3-3.87 M16 3.13a4 4 0 0 1 0 7.75',
-  // server — про инфраструктуру и код (Engineering)
-  engineering:
-    'M2 4h20v6H2z M2 14h20v6H2z M6 7h.01 M6 17h.01',
-  // clipboard-check — про процессы и ритуалы (Practices)
-  practices:
-    'M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2 M9 3h6v4H9z M9 14l2 2 4-4',
-};
-
 interface Node {
   kind: 'root' | 'branch' | 'l1' | 'leaf';
   branchId?: string;
@@ -72,8 +60,6 @@ const edges: Edge[] = [];
 // Per-column widths — растягиваем колонку под самый длинный label,
 // чтобы все узлы в колонке были одной ширины (выравнивание сохраняется).
 // Branch-колонка дополнительно резервирует место под иконку.
-const BRANCH_ICON_W = 20;
-const BRANCH_ICON_GAP = 10;
 let branchColW = MIN_NODE_W;
 let l1ColW = MIN_NODE_W;
 let leafColW = MIN_NODE_W;

--- a/src/content/docs/priorities.mdx
+++ b/src/content/docs/priorities.mdx
@@ -30,39 +30,16 @@ import BranchView from '../../components/BranchView.astro';
 
 <BranchView branchId="culture" variant="priority" />
 
-L2-компетенции под каждой ветвью:
-
-- 🔴 **[Measurement](/The-Way-of-SRE/sre-culture/#measurement)** — SLO / Budget Review, DORA Metrics, Toil Measurement.
-- 🔴 **[Relationship Management](/The-Way-of-SRE/sre-culture/#relationship-management)** — Stakeholder Management, Continuous Feedback, Dev Team Partnership, Communications.
-- 🔴 **[Learning Delivery](/The-Way-of-SRE/sre-culture/#learning-delivery)** — Game Day / Chaos Drills, Postmortem Culture, Incident Response Training, Mentorship, Knowledge Sharing.
-- 🔴 **[Knowledge Management](/The-Way-of-SRE/sre-culture/#knowledge-management)** — Runbooks, Playbooks, Postmortem Database, Architecture Decision Records, Collaboration.
-- 🟡 **[IT Management](/The-Way-of-SRE/sre-culture/#it-management)** — On-Call Budget Management, DR Policy & Stakeholders, SLO Governance.
-- 🟢 **[Organisational Capability Development](/The-Way-of-SRE/sre-culture/#organisational-capability-development)** — SRE Maturity Assessment, SRE Model Adoption, Research & PoC, Team Topologies.
+Подробнее по каждой L1-компетенции и листьям → [SRE Culture](/The-Way-of-SRE/sre-culture/).
 
 ## SRE Engineering
 
 <BranchView branchId="engineering" variant="priority" />
 
-L2-компетенции под каждой ветвью:
-
-- 🔴 **[Observability](/The-Way-of-SRE/sre-engineering/#observability)** — Metrics, Logging, Distributed Tracing, [SLI-based Alerting](/The-Way-of-SRE/leaves/engineering/sli-based-alerting/), End-User Monitoring.
-- 🔴 **[Reliability Engineering](/The-Way-of-SRE/sre-engineering/#reliability-engineering)** — SLO Engineering, Chaos Engineering, Capacity Planning, Disaster Recovery, Resilience Patterns.
-- 🔴 **[IT Infrastructure](/The-Way-of-SRE/sre-engineering/#it-infrastructure)** — Networking, Operating Systems, Containerization & Orchestration, Service Mesh, Cloud Providers.
-- 🔴 **[Programming / Scripting](/The-Way-of-SRE/sre-engineering/#programming-scripting)** — Programming Languages, Shell & CLI Craft, CI/CD.
-- 🟡 **[Toil Reduction](/The-Way-of-SRE/sre-engineering/#toil-reduction)** — Toil Identification, Toil Automation, Toil Tracking.
-- 🟡 **[Configuration Management](/The-Way-of-SRE/sre-engineering/#configuration-management)** — Infrastructure as Code, GitOps.
-- 🔵 **[Database Reliability](/The-Way-of-SRE/sre-engineering/#database-reliability)** — DB Engines, Replication, Backup & Restore, Performance & Monitoring.
+Подробнее по каждой L1-компетенции и листьям → [SRE Engineering](/The-Way-of-SRE/sre-engineering/).
 
 ## SRE Practices
 
 <BranchView branchId="practices" variant="priority" />
 
-L2-компетенции под каждой ветвью:
-
-- 🔴 **[Incident Management](/The-Way-of-SRE/sre-practices/#incident-management)** — Incident Response, Escalation Paths, On-Call Rotation, Status Page Management, MTTR Optimization.
-- 🔴 **[Problem Management](/The-Way-of-SRE/sre-practices/#problem-management)** — Blameless Postmortem, Problem Tracking, Trend Analysis, Preventive Measures, SLO Review Ritual.
-- 🟡 **[Change Management](/The-Way-of-SRE/sre-practices/#change-management)** — Production Readiness Review, Progressive Delivery, Rollback Strategy, Error Budget Gating, Change Risk Assessment.
-- 🟡 **[Information Security](/The-Way-of-SRE/sre-practices/#information-security)** — Vulnerability Management, Security SLOs, Threat Modeling, Supply Chain Security, Secret Management.
-- 🟡 **[Methods & Tools](/The-Way-of-SRE/sre-practices/#methods-tools)** — SRE Toolchain, Policy and Standards, Analysis.
-- 🟡 **[Professional Development](/The-Way-of-SRE/sre-practices/#professional-development)** — Career Pathing for SRE, Strategy Planning, Burnout Prevention, On-Call Design.
-- 🟡 **[Performance Management](/The-Way-of-SRE/sre-practices/#performance-management)** — People Management, Setting Goals, Psychological Safety, Performance Conversations.
+Подробнее по каждой L1-компетенции и листьям → [SRE Practices](/The-Way-of-SRE/sre-practices/).

--- a/src/data/branchIcons.ts
+++ b/src/data/branchIcons.ts
@@ -1,0 +1,20 @@
+// Lucide-style SVG path data для иконок branch-узлов.
+// Виден как 24×24, stroke-based; на branch-узле рисуется через
+// `transform: translate(...) scale(20/24)`.
+//
+// Иконки выбраны по семантике ветви:
+//   culture     — users (люди и команды)
+//   engineering — server (инфраструктура и код)
+//   practices   — clipboard-check (процессы и ритуалы)
+
+export const BRANCH_ICONS: Record<string, string> = {
+  culture:
+    'M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2 M9 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8 M22 21v-2a4 4 0 0 0-3-3.87 M16 3.13a4 4 0 0 1 0 7.75',
+  engineering:
+    'M2 4h20v6H2z M2 14h20v6H2z M6 7h.01 M6 17h.01',
+  practices:
+    'M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2 M9 3h6v4H9z M9 14l2 2 4-4',
+};
+
+export const BRANCH_ICON_W = 20;
+export const BRANCH_ICON_GAP = 10;


### PR DESCRIPTION
## Проблема

На странице `/priorities/` «паучки» (BranchView с `variant=\"priority\"`) визуально и по содержимому не соответствовали главной:

- **Branch-узел** — на главной (Spider) в канонической палитре ветви (Culture amber, Engineering teal, Practices indigo) с lucide-style иконкой; на /priorities/ — accent-синий, без иконки.
- **Leaves** — на главной branch-tinted, на /priorities/ все одинаковые accent-low. На странице приоритетов листья смысла не несут (priority наследуется от L1), только засоряют схему.
- **L2-bullet-списки** под BranchView (Stakeholder Management, Continuous Feedback, DORA Metrics…) — наследие mermaid-эры из `docs/sre-priorities.md`. В `roadmap.ts` L2-узлов нет, только L1 → leaves. Это и создавало ощущение «схема показывает одно, текст — другое».

## Исправление

Четыре атомарных коммита:

1. **refactor(spider)** — вынести `BRANCH_ICONS` в `src/data/branchIcons.ts`, чтобы и Spider, и BranchView делили один источник.
2. **feat(branchview)** — иконка ветви и canonical palette на branch-узле в priority-варианте; branch-узел стал кликабельным (`href: branch.href`).
3. **feat(branchview)** — убрать leaves в priority-варианте. На странице приоритетов цель — показать приоритет L1, листья без priority лишь увеличивают ширину и шум. На главной и navigation-варианте листья остаются.
4. **refactor(priorities)** — удалить stale L2-bullet-списки целиком, заменить на короткую ссылку «Подробнее → SRE Culture/Engineering/Practices».

## Test plan

- [x] `npm run build` — 32 страницы.
- [x] В `dist/priorities/index.html` — 0 `node-leaf` узлов (leaves убраны).
- [x] В `dist/sre-culture/index.html` и `dist/index.html` — `node-leaf` сохранены (navigation/Spider не задеты).
- [ ] После мержа — проверить визуально: на /priorities/ три branch-узла в своих цветах с иконкой, L1 в priority-цветах, листьев нет; ссылки «Подробнее» ведут на 200.