### PR TITLE
feat(leaves): batch-2 — Symptom vs Cause Alerting, Change Governance, Vendor Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ graph LR
 ```
 
 - **[SRE Culture](https://jtprogru.github.io/The-Way-of-SRE/sre-culture/)** — нормы, отношения, обмен опытом. Главный объект — люди и нормы. **8 листьев** на полной глубине.
-- **[SRE Engineering](https://jtprogru.github.io/The-Way-of-SRE/sre-engineering/)** — технические компетенции и стек. Главный объект — системы. **15 листьев** на полной глубине.
-- **[SRE Practices](https://jtprogru.github.io/The-Way-of-SRE/sre-practices/)** — операционные процессы и ритуалы. Главный объект — процесс. **15 листьев** на полной глубине.
+- **[SRE Engineering](https://jtprogru.github.io/The-Way-of-SRE/sre-engineering/)** — технические компетенции и стек. Главный объект — системы. **16 листьев** на полной глубине.
+- **[SRE Practices](https://jtprogru.github.io/The-Way-of-SRE/sre-practices/)** — операционные процессы и ритуалы. Главный объект — процесс. **17 листьев** на полной глубине.
 
 Принцип разделения ветвей, политика контроля детализации, оси priority и SFIA — в [Методологии](https://jtprogru.github.io/The-Way-of-SRE/methodology/).
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -78,6 +78,7 @@ export default defineConfig({
               collapsed: false,
               items: [
                 { label: 'SLI-based Alerting', link: '/leaves/engineering/sli-based-alerting/' },
+                { label: 'Symptom vs Cause Alerting', link: '/leaves/engineering/symptom-vs-cause-alerting/' },
                 { label: 'Alert Fatigue Management', link: '/leaves/engineering/alert-fatigue-management/' },
                 { label: 'SLO Engineering', link: '/leaves/engineering/slo-engineering/' },
                 { label: 'Capacity Planning', link: '/leaves/engineering/capacity-planning/' },
@@ -106,6 +107,7 @@ export default defineConfig({
                 { label: 'Blameless Postmortem', link: '/leaves/practices/blameless-postmortem/' },
                 { label: 'Action Items Tracking', link: '/leaves/practices/action-items-tracking/' },
                 { label: 'Progressive Delivery', link: '/leaves/practices/progressive-delivery/' },
+                { label: 'Change Governance', link: '/leaves/practices/change-governance/' },
                 { label: 'Secrets Management', link: '/leaves/practices/secrets-management/' },
                 { label: 'Threat Modeling', link: '/leaves/practices/threat-modeling/' },
                 { label: 'Vulnerability Management', link: '/leaves/practices/vulnerability-management/' },
@@ -113,6 +115,7 @@ export default defineConfig({
                 { label: 'Architecture Decision Records', link: '/leaves/practices/architecture-decision-records/' },
                 { label: 'One-on-Ones', link: '/leaves/practices/one-on-ones/' },
                 { label: 'Personal Growth Plan', link: '/leaves/practices/personal-growth-plan/' },
+                { label: 'Vendor Management', link: '/leaves/practices/vendor-management/' },
               ],
             },
           ],

--- a/src/content/docs/leaves/culture/dev-team-partnership.md
+++ b/src/content/docs/leaves/culture/dev-team-partnership.md
@@ -73,7 +73,7 @@ description: Партнёрство SRE с продуктовыми команд
 - **[Runbooks](/The-Way-of-SRE/leaves/culture/runbooks/)** — co-ownership: runbook пишутся совместно, иначе SRE дежурит вслепую по dev-сервису.
 - **[Postmortem Culture](/The-Way-of-SRE/leaves/culture/postmortem-culture/)** — joint postmortems с обеими сторонами — обязательное условие сохранения partnership.
 - **[Incident Response](/The-Way-of-SRE/leaves/practices/incident-response/)** — модель ролей (IC и др.) распределяется между SRE и dev в зависимости от engagement model.
-- **Production Readiness Review** *(TBD)* — формализованная граница «product team готов к продакшен».
+- **[Change Governance](/The-Way-of-SRE/leaves/practices/change-governance/)** — PRR — формализованная граница «product team готов к продакшен», описан там как gate.
 
 ## Открытые вопросы
 

--- a/src/content/docs/leaves/culture/service-ownership.md
+++ b/src/content/docs/leaves/culture/service-ownership.md
@@ -67,8 +67,11 @@ description: Систематическое владение production-серв
 - **[Dev Team Partnership](/The-Way-of-SRE/leaves/culture/dev-team-partnership/)** — engagement contract предполагает явное ownership; без него partnership деградирует в «SRE решает всё».
 - **[Incident Response](/The-Way-of-SRE/leaves/practices/incident-response/)** — incident commander смотрит в catalog, чтобы узнать owner и эскалационный путь.
 - **[Backup & Restore](/The-Way-of-SRE/leaves/engineering/backup-restore/)** — caталог содержит backup-метаданные сервиса; без catalog на момент disaster engineers ищут backup вслепую.
+- **[Cost Management](/The-Way-of-SRE/leaves/engineering/cost-management/)** — каталог содержит cost-метаданные: текущий spend, budget, trend. Cost ownership = service ownership.
+- **[Vendor Management](/The-Way-of-SRE/leaves/practices/vendor-management/)** — каталог содержит upstream vendor dependencies сервиса; vendor incident playbook привязан к owner.
+- **[Change Governance](/The-Way-of-SRE/leaves/practices/change-governance/)** — каталог содержит PRR status: passed / not passed / in progress. Часть «есть ли owner и готовность к prod».
 
 ## Открытые вопросы
 
-- Под L1 `IT Management` остаются темы, которые могут стать отдельными листьями: **Cost Management** (cloud spend ownership, unit economics), **Vendor Management** (контракты, exit-стратегии), **Change Governance** (CAB, async review, журнал аудита), **Production Access Audit** (compliance-readiness). Service Ownership — фундамент для всех четырёх.
+- Под L1 `IT Management` остаются темы — например, **Production Access Audit** (compliance-readiness, who has shell access to prod). Cost / Vendor / Change Governance уже выделены в отдельные листья.
 - Граница со `Methods & Tools`: catalog как инструмент частично пересекается. Здесь — про ownership как практику; там — про выбор tooling.

--- a/src/content/docs/leaves/engineering/alert-fatigue-management.md
+++ b/src/content/docs/leaves/engineering/alert-fatigue-management.md
@@ -72,10 +72,9 @@ description: Систематическое снижение alert fatigue — a
 - **[Toil Tracking](/The-Way-of-SRE/leaves/engineering/toil-tracking/)** — alert fatigue — крупный класс toil; tracking ловит signal «слишком много manual response → automate».
 - **[Postmortem Culture](/The-Way-of-SRE/leaves/culture/postmortem-culture/)** — noisy on-call смена — кандидат на постмортем (системная проблема, не «норма»).
 - **[SLO Engineering](/The-Way-of-SRE/leaves/engineering/slo-engineering/)** — SLO для алертинга как мета-практика («≥ 95% pages actionable»).
+- **[Symptom vs Cause Alerting](/The-Way-of-SRE/leaves/engineering/symptom-vs-cause-alerting/)** — alert hygiene начинается с правильного выбора что алертить: symptom-side reduces false-positive rate в принципе, не post-hoc.
 
 ## Открытые вопросы
-
-- **Symptom vs Cause Alerting** *(TBD)* — подтема alert design, пересекается с Alert Fatigue Management через symptom-based reduces false-positive rate.
 - **Auto-Remediation Patterns** *(TBD)* — детальные паттерны (Lambda / k8s operator / Argo Workflow); как safely прогрессивно автоматизировать.
 - **Alert Routing & Escalation Patterns** — детализация Alertmanager routing trees, criticality levels (SHEDDABLE / CRITICAL_PLUS из SRE Book гл. 21).
 - **Maintenance Window / Silencing Practices** — как правильно делать planned silences без потери visibility; TTL hygiene.

--- a/src/content/docs/leaves/engineering/ci-cd.md
+++ b/src/content/docs/leaves/engineering/ci-cd.md
@@ -81,10 +81,10 @@ description: Pipeline сборки и доставки кода как кодо�
 - **[Supply Chain Security](/The-Way-of-SRE/leaves/practices/supply-chain-security/)** — SLSA, Sigstore, SBOM, ephemeral runners. CI/CD pipeline — главный surface для supply chain.
 - **[Secrets Management](/The-Way-of-SRE/leaves/practices/secrets-management/)** — OIDC; CI/CD — один из главных контекстов потенциальной утечки.
 - **[Service Ownership](/The-Way-of-SRE/leaves/culture/service-ownership/)** — service team owns its pipeline; не «централизованный DevOps team настраивает за всех».
+- **[Change Governance](/The-Way-of-SRE/leaves/practices/change-governance/)** — PRR / production readiness review реализуется как gate в pipeline; classification standard / normal change опирается на pipeline-level evidence.
 
 ## Открытые вопросы
 
 - **Supply Chain Security** *(TBD)* — отдельный лист про SLSA framework, Sigstore, SBOM. Сосед к Vulnerability Management.
-- **Pre-Deployment Review** *(TBD)* — production readiness review как gate в pipeline.
 - **DORA Metrics как отдельная практика** — FOUR KEYS как самостоятельная measurement practice (definitions, dashboards, anti-gaming) может стать листом под Measurement L1 в Culture.
 - **Build Reproducibility / Hermetic Builds** — отдельная подтема (deterministic builds, Bazel-style, locked deps).

--- a/src/content/docs/leaves/engineering/sli-based-alerting.md
+++ b/src/content/docs/leaves/engineering/sli-based-alerting.md
@@ -80,8 +80,7 @@ description: Алерт на нарушение пользовательског
 - **[Alert Fatigue Management](/The-Way-of-SRE/leaves/engineering/alert-fatigue-management/)** — соседний концепт: SLI-based подход — основной инструмент борьбы с alert fatigue, но не единственный.
 - **[Runbooks](/The-Way-of-SRE/leaves/culture/runbooks/)** — обязательная привязка: алерт без runbook не проходит ревью.
 - **[SLO / Budget Review](/The-Way-of-SRE/leaves/culture/slo-budget-review/)** — потребитель: ритуал ревью опирается на данные, накопленные SLO-based алертами.
+- **[Symptom vs Cause Alerting](/The-Way-of-SRE/leaves/engineering/symptom-vs-cause-alerting/)** — *как* алерт устроен — здесь; *на что именно* алертить (симптом, не причина) — там. Читать вместе.
 
 ## Открытые вопросы
-
-- Стоит ли заводить отдельный лист `Symptom vs Cause Alerting` или это часть данного листа? Сейчас зафиксировано как best practice здесь.
 - Я не знаю хорошего ответа на «как ставить алерты для batch-сервисов и pipelines, где user-facing SLI плохо определён». RED-метрики (rate / errors / duration) работают для онлайн-сервисов; для batch — freshness / throughput / correctness, но как ставить burn rate на freshness, когда нагрузка по запросам нерегулярная — я в публичной литературе консенсуса не видел. Если у вас есть опыт — расскажите через PR.

--- a/src/content/docs/leaves/engineering/slo-engineering.md
+++ b/src/content/docs/leaves/engineering/slo-engineering.md
@@ -72,6 +72,8 @@ description: Инженерная сторона SLO — определение 
 - **[Networking](/The-Way-of-SRE/leaves/engineering/networking/)** — большинство SLI строятся на сетевых метриках (latency, error rate, DNS); знание networking-стека определяет, что измеримо корректно.
 - **[Programming Languages](/The-Way-of-SRE/leaves/engineering/programming-languages/)** — инструментирование SLI требует кода в сервисе (Prometheus client, OpenTelemetry SDK).
 - **[Capacity Planning](/The-Way-of-SRE/leaves/engineering/capacity-planning/)** — capacity planning опирается на SLO как на reliability-таргет.
+- **[Vendor Management](/The-Way-of-SRE/leaves/practices/vendor-management/)** — vendor SLAs — нижняя граница composite SLO math: own SLO ≤ product(vendor SLAs × own reliability) без явной redundancy.
+- **[Symptom vs Cause Alerting](/The-Way-of-SRE/leaves/engineering/symptom-vs-cause-alerting/)** — symptom-side SLI — то, на что алертит paging-level; cause-side — diagnostic context.
 
 ## Открытые вопросы
 

--- a/src/content/docs/leaves/engineering/symptom-vs-cause-alerting.md
+++ b/src/content/docs/leaves/engineering/symptom-vs-cause-alerting.md
@@ -1,0 +1,87 @@
+---
+title: Symptom vs Cause Alerting
+description: Дисциплина alert design — page на симптомы (то, что чувствует пользователь), не на причины; cause-based данные — для дебага, не для пейджера
+---
+
+:::note[Метаданные листа]
+- **Ветвь:** Engineering
+- **Путь:** Observability / Symptom vs Cause Alerting
+- **SFIA-уровни:** 3, 4, 5, 6
+- **Приоритет:** Must Have
+- **Статус:** draft
+:::
+
+«DB CPU > 80% → page» — типичный cause-based алерт. При DB outage он генерирует 50 пейджеров под одним инцидентом и парализует on-call; а при slow query на decoupled-сервисе пейджит при работающем продукте. Symptom-based алерт ловит то, что реально чувствует пользователь — latency, error rate, availability — и пейджит один раз за инцидент, ровно когда нужно. Rob Ewaschuk в 2014 году написал внутренний Google-документ «My Philosophy on Alerting», который стал каноном; SRE Book главы 6 и 4 закрепили это в индустрии. Лист — про дисциплину различения и про то, как реструктурировать alert portfolio после миграции на SLO-driven подход.
+
+Граница: [SLI-based Alerting](/The-Way-of-SRE/leaves/engineering/sli-based-alerting/) — *как* алерт устроен (SLI как сигнал, burn rate как порог); этот лист — *на что именно* алертить (симптом, не причина). [Alert Fatigue Management](/The-Way-of-SRE/leaves/engineering/alert-fatigue-management/) — что делать, когда система уже зашумлена; этот — как с самого начала не зашумлять.
+
+## Что должен уметь
+
+Главный навык на уровне L4 — формулировать **golden signals** (latency / errors / traffic / saturation) для своего сервиса так, чтобы symptom-side покрывал «что пользователь почувствует», а cause-side покрывал «куда смотреть в дебаге». Я регулярно вижу команды, которые знают слова «golden signals» наизусть — но в их alert config 80% правил cause-based (CPU / memory / disk / connections), и при downstream outage on-call просто тонет в шуме. Различение видно не в формулировке принципа, а в том, какие правила реально active при `page` priority.
+
+- **L3** — Отличает symptom-based от cause-based алерта на примере конкретного правила; объясняет, почему `error rate > 1%` — symptom, а `connection pool > 80%` — cause.
+- **L3** — Понимает alert amplification: при downstream outage cause-based алерты на dependencies + cascading effects дают N-кратный шум на тот же incident.
+- **L4** — Проектирует **golden signals** для своего сервиса: latency (per percentile), errors (rate + share), traffic (qps / req/min), saturation (utilization vs capacity). Все 4 — symptom-side; cause-side — отдельный набор.
+- **L4** — Использует cause-based данные как **secondary** в runbook'е, а не **primary** в alert. Cause-метрики в dashboard, симптомы — в пейджере.
+- **L5** — Применяет multi-burn-rate alerting для symptom-side SLI: быстрая burn (fast burn 1h / 5min) и медленная (slow burn 6h / 30min) — один алерт, два window'а.
+- **L5** — Регулярно (раз в квартал) пересматривает alert portfolio: какие cause-based выкинуть как noise / понизить до dashboard / оставить как secondary; какие symptom-side добавить, если incident прошёл без алерта.
+- **L6+** — Внедряет alert-as-code дисциплину: каждое alert rule имеет owner, runbook link, SLI / threshold rationale, severity, ожидание частоты (alert per quarter), review cycle.
+- **L6+** — Связывает alerting policy с SLO program: paging-level алерты только на SLO burn; ticket-level — на внутренние saturation indicators; dashboard-only — на cause-side и diagnostic signals.
+
+## Материалы
+
+### Книги
+
+- Betsy Beyer et al. (eds) — **[Site Reliability Engineering](https://sre.google/sre-book/monitoring-distributed-systems/)** (O'Reilly, 2016), глава 6 «Monitoring Distributed Systems». Канонический разбор: 4 golden signals, symptoms vs causes, white-box vs black-box monitoring. Если выбирать одну главу — эту.
+- Betsy Beyer et al. (eds) — **[Site Reliability Engineering](https://sre.google/sre-book/practical-alerting/)** (O'Reilly, 2016), глава 4 «Service Level Objectives». Связка SLO ↔ alert: paging only on SLO violations.
+- Mike Julian — **[Practical Monitoring](https://www.oreilly.com/library/view/practical-monitoring/9781491957349/)** (O'Reilly, 2017). Глава «Designing Meaningful Alerts». Альтернативный взгляд той же идеи: разделение alerts (page) / warnings (ticket) / informationals (log).
+- Cindy Sridharan — **[Distributed Systems Observability](https://www.oreilly.com/library/view/distributed-systems-observability/9781492033431/)** (O'Reilly, 2018). Контекст: почему observability ≠ monitoring; почему cause-debugging уходит в трейсы / логи, а alerting остаётся на симптомах.
+
+### Статьи и доклады
+
+- Rob Ewaschuk — **[My Philosophy on Alerting](https://docs.google.com/document/d/199PqyG3UsyXlwieHaqbGiWVa8eMWi8zzAn0YfcApr8Q/preview)** (Google internal, 2014). Первоисточник принципа «page on symptoms, not causes». Короткий документ — лучшая первая статья по теме. Главный публичный кейс — см. ниже.
+- Betsy Beyer, Niall Murphy, Liz Fong-Jones, David Rensin — **[The Site Reliability Workbook](https://sre.google/workbook/alerting-on-slos/)** (O'Reilly, 2018), глава 5 «Alerting on SLOs». Многоуровневые burn rate alerts — практика, развивающая Ewaschuk: 2 percent / 5 percent / 10 percent budget burn windows, multi-window multi-burn-rate.
+- Charity Majors — **[Why We Built Honeycomb](https://www.honeycomb.io/blog/why-we-built-honeycomb)**. Контекст высокой кардинальности и observability как противопоставления classical monitoring. Полезно как фон, а не как канон по alerting.
+
+### Инструменты
+
+- **[Prometheus + Alertmanager](https://prometheus.io/docs/alerting/latest/overview/)** — де-факто стандарт. Multi-window multi-burn-rate реализуется через `for` + recording rules. Sloth / Pyrra / OpenSLO — генераторы SLO-aware alert rules поверх Prometheus.
+- **[Grafana](https://grafana.com/oss/alerting/)** / **[Datadog](https://docs.datadoghq.com/monitoring/)** / **[New Relic](https://docs.newrelic.com/docs/alerts-applied-intelligence/)** — alerting на векторах observability platforms; pattern одинаков, синтаксис разный.
+- **[Sloth](https://sloth.dev/)** / **[Pyrra](https://github.com/pyrra-dev/pyrra)** / **[OpenSLO](https://openslo.com/)** — SLO-as-code; alert-rules генерируются из SLO spec автоматически. По моим наблюдениям, чаще выбирают Sloth — proven и интегрирован с Prometheus.
+- **Анти-инструмент:** «алёрт-rule на каждую метрику dashboard» — антипаттерн, доводящий до alert fatigue за месяц. Pattern «алерт — это пейджер; всё остальное — dashboard» — самый сильный фильтр.
+
+## Best practices
+
+Главный публичный кейс — **Rob Ewaschuk, «My Philosophy on Alerting» (Google internal, ~2014)**. Документ короткий (10 страниц), и каждая его рекомендация выдержала ~10 лет: «page on symptoms, not causes», «every page must be actionable», «if you don't know what to do, it shouldn't be a page», «alert quality matters more than alert quantity». Я регулярно вижу команды, которые читали SRE Book, но не сам этот документ — и теряют главный nuance: Ewaschuk пишет про **операционную работу человека** ночью, не про «правильный мониторинг». Это смещает рамку: alert design — это UX-задача для on-call инженера в 3 часа ночи. Один час чтения и пять лет дисциплины.
+
+**Короткие правила:**
+
+- **Page только на симптомы.** Cause-based данные — в dashboard и runbook; пейджит только то, что реально означает «пользователь страдает прямо сейчас или скоро».
+- **Каждый алерт — actionable.** Если on-call не знает, что делать с сигналом, это не алерт, это лог. «Alert investigation cookbook» из 30 шагов «может быть X, может быть Y» — признак того, что условие алерта слишком широкое.
+- **One incident → one page.** Cause-based алерты на dependencies дают N-кратный шум на тот же downstream outage. Symptom-side даёт один пейджер. Это лакмус: если incident сгенерировал > 3 пейджеров — alert portfolio сломан.
+
+Подробнее:
+
+**Cause-based алерты не отменяются — они переезжают.** Распространённый страх: «если уберём CPU alert, кто-то пропустит CPU exhaustion». Cause-side метрики остаются — но в dashboard и runbook, не в pager. Когда symptom alerts (latency / errors) поднимаются, on-call открывает dashboard и сразу видит cause-side как контекст. Это разделение primary signal (что чувствует пользователь) и diagnostic signal (где смотреть в дебаге).
+
+**Multi-burn-rate alerting — практический шаг от symptom-аксиомы к работающей формуле.** Чистый «error rate > 1%» — слишком reactive (срабатывает только в очевидном инциденте); чистый «budget burn 2%» — слишком reactive по-другому (срабатывает после факта). Multi-window: fast burn (1h window @ 14.4x burn) пейджит быстрый incident; slow burn (6h window @ 6x burn) пейджит медленный degradation. SRE Workbook глава 5 — формулы и параметры. По моим наблюдениям, разница между командами с whitelined alerts и зашумлёнными — наличие multi-burn-rate почти всегда; всё остальное вторично.
+
+**Quarterly alert review — обязательная гигиена.** Команды, у которых alert portfolio «накапливается» без review — через год имеют сотни правил, из которых треть не срабатывала, треть срабатывала шумом, и треть актуальна. Раз в квартал — review каждого правила: срабатывал ли за период? было ли actionable? стоит ли понизить / повысить / убрать? Без review alert design деградирует к baseline alert fatigue даже при хорошем initial design.
+
+**Black-box ≠ замена white-box.** Symptom monitoring часто ассоциируется с black-box (синтетические probes, external uptime checks). Это полезно, но не достаточно: black-box ловит «сервис недоступен», но не «сервис отвечает, но 20% запросов с ошибкой». White-box symptom (error rate / latency из самого сервиса) и black-box (synthetic user journey) — комплементарны. Я регулярно вижу команды, у которых либо только black-box (миссит частичные деградации), либо только white-box (миссит network / DNS / TLS issues между пользователем и сервисом).
+
+## Связанные листья
+
+- **[SLI-based Alerting](/The-Way-of-SRE/leaves/engineering/sli-based-alerting/)** — *как* устроен алерт (SLI / threshold / burn rate); этот лист — *на что* алертить. Читать вместе.
+- **[Alert Fatigue Management](/The-Way-of-SRE/leaves/engineering/alert-fatigue-management/)** — что делать, когда alert portfolio уже шумит; этот — как с самого начала не разводить шум.
+- **[SLO Engineering](/The-Way-of-SRE/leaves/engineering/slo-engineering/)** — symptom-side алерты привязаны к SLO; budget burn rate — каноническая формула.
+- **[Runbooks](/The-Way-of-SRE/leaves/culture/runbooks/)** — каждый алерт ссылается на runbook, где cause-side metrics — diagnostic step, не trigger.
+- **[Incident Response](/The-Way-of-SRE/leaves/practices/incident-response/)** — actionable алерт = первый шаг IR; неactionable алерт ломает IR с самого начала.
+- **[Resilience Patterns](/The-Way-of-SRE/leaves/engineering/resilience-patterns/)** — circuit breaker / retry / shed metrics — это secondary indicators (показывают, что patterns активны), не primary alerts.
+
+## Открытые вопросы
+
+- **Alert SLO** *(TBD)* — meta-SLI для самого alerting'а: alert precision (true positive rate), recall, time-to-page-after-incident. Отдельный лист про измерение качества alert program.
+- **Synthetic Monitoring как practice** *(TBD)* — black-box probes, end-user monitoring (RUM), synthetic user journeys. Соседняя ветка observability.
+- **Anomaly Detection как замена threshold-based** *(TBD)* — Holt-Winters / Prophet / ML-based; границы применимости.
+- Я не уверен, как **корректно ловить partial degradation** на feature flag уровне (часть пользователей в плохом cohort). Если у вас есть опыт — расскажите через PR.

--- a/src/content/docs/leaves/practices/change-governance.md
+++ b/src/content/docs/leaves/practices/change-governance.md
@@ -1,0 +1,90 @@
+---
+title: Change Governance
+description: Дисциплина границ изменения в production — change classification, production readiness review, freeze policy, error budget gating
+---
+
+:::note[Метаданные листа]
+- **Ветвь:** Practices
+- **Путь:** Change Management / Change Governance
+- **SFIA-уровни:** 3, 4, 5, 6
+- **Приоритет:** Must Have
+- **Статус:** draft
+:::
+
+«Мы catit anytime, у нас zero-friction culture» — лозунг, за которым часто стоит «у нас нет production readiness, мы катит и надеемся». Change Governance — это **дисциплина границ**, не bureaucracy: какие изменения попадают на fast lane (standard change, без review), какие требуют PRR, какие никогда не катятся в peak season. Я регулярно вижу команды, которые думают, что бинарный выбор — либо «CAB-meeting раз в неделю» (heavy bureaucracy), либо «zero process» (Russian roulette). Между ними — лёгкий, явный classification и явные gates, которые добавляют 30 секунд к standard change и 2 дня к high-risk change. Это и есть здоровое governance.
+
+Граница: [Progressive Delivery](/The-Way-of-SRE/leaves/practices/progressive-delivery/) — *техника* deployment (canary / blue-green / feature flag). Change Governance — *policy и process*: что классифицируется как high-risk, кто approves, когда заморозка. [Architecture Decision Records](/The-Way-of-SRE/leaves/practices/architecture-decision-records/) — про architectural decisions; change governance — про operational/release decisions с риском в production.
+
+## Что должен уметь
+
+Главный навык на уровне L5 — спроектировать **change classification** так, чтобы 80–90% изменений шли по fast lane (standard change, code review достаточен), 10–15% — по normal lane (PRR / change review для нестандартных изменений), 5% — по freeze-bypass procedure для emergency. По моим наблюдениям, неработающий change governance — это либо «всё normal» (вся работа замирает в CAB-meetings) либо «всё standard» (никакие нестандартные изменения не получают review). Healthy governance — это явная категория «standard» с критериями, чтобы команда знала, когда «не нужен review».
+
+- **L3** — Следует existing change governance: знает, какой класс изменения требует какого review (PR review / RFC / PRR), готовит change request с rollback plan, blast radius assessment, validation steps.
+- **L3** — Понимает разницу между standard / normal / emergency change; не маркирует normal change как emergency для bypass review.
+- **L4** — Проводит **Production Readiness Review (PRR)** для нового сервиса или major изменения: SLO defined, monitoring + alerts, runbooks, on-call coverage, capacity plan, rollback validated.
+- **L4** — Реализует change freeze policy: peak season (Black Friday, end-of-quarter close), major launches, mobile release cuts. Freeze ≠ полный stop — это явный whitelist того, что разрешено.
+- **L5** — Проектирует change classification system для команды / org: критерии standard / normal / emergency, approver chain для каждой категории, метрики performance (% standard, time-to-approval normal, post-change incident rate).
+- **L5** — Включает **error budget gating**: при сожжённом SLO budget автоматически фриз feature changes; разрешены только reliability fixes. Без gating SLO становится дашбордом, не tool принятия решений.
+- **L6+** — Связывает change governance с org SLO program: change risk assessment use SLO data (предыдущие incidents в данной области → выше risk weighting); calibration risk оценок раз в квартал.
+- **L6+** — Внедряет PRR program для новых сервисов как gate перед production: written checklist, owner of review process, follow-up на open items до GA.
+
+## Материалы
+
+### Книги
+
+- Betsy Beyer et al. (eds) — **[Site Reliability Engineering](https://sre.google/sre-book/evolving-sre-engagement-model/)** (O'Reilly, 2016), глава 32 «The Evolving SRE Engagement Model». Google's PRR процесс — каноническое описание PRR как gate перед SRE-engagement. Главный публичный источник по PRR.
+- Jennifer Davis, Katherine Daniels — **[Effective DevOps](https://www.oreilly.com/library/view/effective-devops/9781491926291/)** (O'Reilly, 2016). Глава про change management в DevOps-контексте: как избежать bureaucracy без потери контроля.
+- Mark Schwartz — **[A Seat at the Table](https://itrevolution.com/product/a-seat-at-the-table/)** (IT Revolution, 2017). Не SRE-книга, но фундамент про change governance в продуктовых организациях: почему ITIL-style change management не работает в agile-команде и что вместо.
+- Nicole Forsgren, Jez Humble, Gene Kim — **[Accelerate](https://itrevolution.com/product/accelerate/)** (IT Revolution, 2018). Связка change governance ↔ deployment frequency ↔ change failure rate (DORA-метрики). Главный аргумент против heavy change approval boards.
+
+### Статьи и доклады
+
+- **[ITIL 4: Change Enablement](https://www.axelos.com/certifications/itil-service-management/itil-4-foundation)**. Современный ITIL отказался от «Change Management» в пользу «Change Enablement» (subtle, но важный shift). Полезно для словаря и для разговора с enterprise IT.
+- Knight Capital Group — **[SEC Filing on August 1 2012 trading loss](https://www.sec.gov/litigation/admin/2013/34-70694.pdf)**. Не статья про governance, но первичный источник кейса (см. ниже).
+- John Allspaw — **[On Being a Senior Engineer](https://www.kitchensoap.com/2012/10/25/on-being-a-senior-engineer/)** (Kitchen Soap, 2012). Косвенно: change governance — это senior judgement, а не process; стандарты appropriated for context.
+
+### Инструменты
+
+- **Issue tracker (Jira / Linear / GitHub Issues)** — primary запись change request: classification, owner, approver, status. Без явной записи governance существует только в Slack.
+- **[ServiceNow Change Management](https://www.servicenow.com/products/change-management.html)** / **Jira Service Management** — enterprise change platforms; полезны при regulatory compliance (SOX, ISO 27001, PCI-DSS). Для команды до 50 человек обычно overkill.
+- **[FireHydrant Change Tracking](https://firehydrant.com/) / [incident.io](https://incident.io/)** — incident platforms с change tracking: видно, какие changes были до incident (forensics + future risk-weighting).
+- **PRR checklist as living document** — markdown в repo / Notion. Самый важный инструмент, не technology. По моим наблюдениям, простой checklist выигрывает у любой specialized platform для команд до ~200 engineers.
+- **Анти-инструмент:** weekly CAB meeting как primary mechanism. Если 80% changes идут через meeting — change governance мертв; команда либо обходит, либо саботирует.
+
+## Best practices
+
+Главный публичный кейс — **Knight Capital Group, August 1, 2012**. За 45 минут утром на Уолл-стрит компания потеряла **$440M** из-за deploy-ошибки: deploy script был run на 7 из 8 серверов; восьмой сервер запустил старую версию кода с repurposed feature flag, отправил миллиарды buy/sell orders и обанкротил компанию через 4 дня. SEC-документ детально разбирает: не было PRR для repurposed feature flag, deploy script не проверял consistency между серверами, rollback procedure не валидировалась. Я регулярно вижу команды, у которых такое же сочетание factors («deploy на N серверов, потом проверим»; «feature flag repurposed без change record») — но без trading-volume Knight Capital impact меньше, и команда не учится. Knight Capital — лучший public reminder того, что governance не nice-to-have.
+
+**Короткие правила:**
+
+- **Classification обязателен.** Без явной разницы «standard / normal / emergency» все changes равнозначны — и команда либо тонет в process, либо обходит его. 80–90% changes должны быть standard (fast lane, code review достаточен).
+- **Каждый change имеет rollback plan, validated.** «Rollback задеплоим если что» — не plan. Pre-deployment validation rollback на staging для high-risk changes — обязательна.
+- **PRR — обязательный gate для новых сервисов перед production.** Написанный checklist, owner of review, follow-up open items. PRR без follow-up — theatre.
+
+Подробнее:
+
+**Production Readiness Review — checklist, не interview.** В Google PRR — комбинация written review (checklist) + meeting (questions). Команды часто пытаются делать PRR как «meeting раз в неделю» — это не работает, потому что preparation важнее meeting'а. Healthy PRR: команда сервиса заполняет written checklist (SLO defined, monitoring + alerts, runbooks present, on-call configured, capacity plan, dependencies mapped, rollback validated, security review done); meeting — дополнение к review, а не replacement. По моим наблюдениям, если PRR существует только как meeting — checklist деградирует к «формальностям», и через год PRR становится theatre.
+
+**Error budget gating связывает change governance с SLO program.** Без gating SLO — dashboard, который никто не смотрит. С gating SLO становится tool принятия решений: budget сожжён → пауза feature changes, разрешены только reliability fixes. Это не «всем замолчать» — это явный сигнал, что приоритеты смещаются. Я регулярно вижу команды, которые объявили SLO + error budget, но не реализовали gating — и через полгода budget chronically negative, никаких изменений в поведении нет, потому что нет actual consequence.
+
+**Change freeze ≠ полный stop.** Распространённый страх: «freeze = команда простаивает». Healthy freeze — это явный whitelist: «во время Black Friday week разрешены только reliability fixes / security patches с SEV2+; feature changes — отложены на post-freeze». Whitelist + duration + signed-off list — лёгкая дисциплина. Freeze без whitelist становится либо ignored (все продолжают катит), либо болезненно строгим (важные fixes не доезжают).
+
+**Standard change category — главный мускул governance.** Парадоксально: качество governance мерится не тем, как строго проходят high-risk changes, а тем, как много changes квалифицируются как standard (fast lane). Если 50% changes требуют review — governance душит team velocity и саботируется. Healthy ratio: 80–90% standard (proven pattern, low risk: bugfix в одном сервисе, config change validated by tests, dependency bump within minor version), 10–15% normal (требует PRR / review), 1–5% emergency / freeze-bypass.
+
+## Связанные листья
+
+- **[Progressive Delivery](/The-Way-of-SRE/leaves/practices/progressive-delivery/)** — техника deployment; canary / blue-green / feature flag — реализация safe rollout. Этот лист — policy: что катить и кто approves; progressive delivery — как катить безопасно.
+- **[SLO Engineering](/The-Way-of-SRE/leaves/engineering/slo-engineering/)** — error budget — input для change gating. SLO без gating — дашборд, не tool.
+- **[Architecture Decision Records](/The-Way-of-SRE/leaves/practices/architecture-decision-records/)** — ADR — для architectural decisions (выбор технологии, design pattern); change governance — для operational decisions (что и когда катит).
+- **[Action Items Tracking](/The-Way-of-SRE/leaves/practices/action-items-tracking/)** — PRR open items — это AIs; tracking их выполнения до GA — часть PRR follow-through.
+- **[Incident Response](/The-Way-of-SRE/leaves/practices/incident-response/)** — change as primary suspect: первое, что смотрит IC после page — recent deploys.
+- **[Service Ownership](/The-Way-of-SRE/leaves/culture/service-ownership/)** — service catalog содержит PRR status сервиса (passed / not passed / in progress); это часть «есть ли owner и готовность к prod».
+- **[Blameless Postmortem](/The-Way-of-SRE/leaves/practices/blameless-postmortem/)** — change-related incidents → post-mortem AIs часто касаются governance (отсутствие PRR, broken rollback, missed approval).
+
+## Открытые вопросы
+
+- **Production Readiness Review как отдельный лист** *(TBD)* — детальный checklist, ownership, scaling PRR на 50+ сервисов.
+- **Change Risk Assessment Frameworks** *(TBD)* — heuristics для оценки risk: blast radius × probability × reversibility. Нет canonical модели; разные команды строят свои.
+- **Change Failure Rate как DORA-метрика** — измерение качества change governance через post-change incident rate; связь с deployment frequency (Accelerate). Может стать частью SLO Engineering или separate leaf.
+- **Compliance-Driven Change Management** *(TBD)* — SOX / PCI-DSS / SOC2 формальные требования к change records; пересечение с regulatory leaves.
+- Я не уверен, **где правильная граница** между Change Governance и Progressive Delivery для команд, где governance lightweight (deploy on push, no explicit review). Если у вас есть рабочая модель — расскажите через PR.

--- a/src/content/docs/leaves/practices/progressive-delivery.md
+++ b/src/content/docs/leaves/practices/progressive-delivery.md
@@ -73,9 +73,8 @@ description: Выкатка изменений малыми долями с heal
 - **[SLO Engineering](/The-Way-of-SRE/leaves/engineering/slo-engineering/)** — SLO определяет, насколько safe canary phase; без явного SLO health gate настроить нельзя.
 - **[GitOps](/The-Way-of-SRE/leaves/engineering/gitops/)** — Argo Rollouts (с ArgoCD) и Flagger (с Flux) — GitOps-нативные tools для progressive delivery.
 - **[Test Strategy](/The-Way-of-SRE/leaves/engineering/test-strategy/)** — pre-deploy tests vs canary как runtime test; дополняют друг друга.
+- **[Change Governance](/The-Way-of-SRE/leaves/practices/change-governance/)** — *техника* deployment (этот лист) и *policy / process* (governance) — соседние практики. Canary без явного change classification — half practice.
 
 ## Открытые вопросы
-
-- **Pre-Deployment Review** *(TBD)* — для high-risk изменений (data migration / security / regulatory).
 - **Rollback Discipline** *(TBD)* — углублённая тема: rollback testing (regular fire drills), automated rollback testing in CI, time-to-rollback как метрика.
 - **Database Migration Patterns** — детальная схема (expand-contract, dual-write, backfill, shadow read).

--- a/src/content/docs/leaves/practices/supply-chain-security.md
+++ b/src/content/docs/leaves/practices/supply-chain-security.md
@@ -82,6 +82,7 @@ SolarWinds (2020), Codecov (2021), 3CX (2023), xz-utils (2024) — атака н
 - **[Progressive Delivery](/The-Way-of-SRE/leaves/practices/progressive-delivery/)** — verify-on-deploy admission policies встроены в deployment pipeline.
 - **[Infrastructure as Code](/The-Way-of-SRE/leaves/engineering/infrastructure-as-code/)** — Terraform modules / Helm charts / Ansible roles тоже supply chain. Аналогичные практики: signed releases, pinned versions, SBOM.
 - **[Incident Response](/The-Way-of-SRE/leaves/practices/incident-response/)** — supply chain compromise — особый класс инцидентов: огромный blast radius, remediation требует revoke-and-rotate scope.
+- **[Vendor Management](/The-Way-of-SRE/leaves/practices/vendor-management/)** — security-side зависимостей (этот лист) и reliability-side (vendor management) — соседние практики с общим vendor inventory.
 
 ## Открытые вопросы
 

--- a/src/content/docs/leaves/practices/vendor-management.md
+++ b/src/content/docs/leaves/practices/vendor-management.md
@@ -1,0 +1,95 @@
+---
+title: Vendor Management
+description: Engineering-практика управления зависимостями от внешних сервисов — vendor SLO, composite math, concentration risk, vendor incident playbook
+---
+
+:::note[Метаданные листа]
+- **Ветвь:** Practices
+- **Путь:** Sourcing / Vendor Management
+- **SFIA-уровни:** 3, 4, 5, 6
+- **Приоритет:** Mandatory
+- **Статус:** draft
+:::
+
+«Cloudflare лежит — мы тоже лежим, ничего не поделаешь» — позиция, легальная для разговора с CEO раз в год, но не для каждый месяц. Vendor management — это **engineering practice**, не «купить контракт у procurement»: понять зависимости, измерить SLO-impact каждого vendor, иметь fallback стратегию для критичных, regularly review portfolio. SRE — естественная точка ответственности, потому что vendor-outage — это incident, и зависимости видно из топологии. По моим наблюдениям, чаще всего vendor management в SRE-команде существует фрагментарно: «AWS bill курирует FinOps, status page Cloudflare смотрит DevOps, Stripe owns billing team», — и в день outage Cloudflare никто не знает, какие сервисы у нас критически зависят и какой emergency playbook применять.
+
+Граница: [Service Ownership](/The-Way-of-SRE/leaves/culture/service-ownership/) — каталог *наших* сервисов; vendor management — каталог *их* сервисов с *нашей* зависимостью. [Supply Chain Security](/The-Way-of-SRE/leaves/practices/supply-chain-security/) — security-side dependencies (CVE, SBOM, signed artifacts); vendor management — reliability-side (SLA, outage history, fallback). [Cost Management](/The-Way-of-SRE/leaves/engineering/cost-management/) — финансовая сторона vendor отношений.
+
+## Что должен уметь
+
+Главный навык на уровне L5 — измерять **vendor's contribution to own SLO** через composite math: если vendor SLA — 99.9%, и vendor — критическая зависимость в request path, наш user-facing SLO не может быть выше 99.9% без явной redundancy / fallback / degraded mode. Я регулярно вижу команды, которые декларируют 99.95% SLO, при этом зависят от 3 vendors с 99.9% SLA — арифметика не сходится с самого начала. Это не значит «не использовать vendor»: это значит признать, что без redundancy наш SLO — composite, и формула должна быть явной.
+
+- **L3** — Знает critical vendors своего сервиса (cloud / DNS / CDN / auth / payment / observability / messaging); читает их public status page и historical incidents.
+- **L3** — Подписан на vendor status updates; в incident на vendor — проверяет dashboard через 5 минут, не через час.
+- **L4** — Поддерживает **vendor incident playbook** для критичных vendors: что делать, когда Cloudflare / AWS region / Stripe / Auth0 down. Конкретные steps, не «свяжемся с support».
+- **L4** — Регулярно проверяет vendor SLA против actual uptime: vendor public commitments vs measured performance. Расхождение — input для review.
+- **L5** — Композитный SLO math: какая часть бюджета остаётся под нашу собственную работу после вычитания vendor budget. Без явной арифметики SLO theatre.
+- **L5** — Vendor risk assessment: dependency graph, concentration risk (single vendor handles N critical paths), switching cost, vendor lock-in metrics.
+- **L6+** — Strategic vendor portfolio: multi-cloud / multi-CDN trade-off (cost vs availability vs ops overhead), vendor diversification policy, escape hatch design.
+- **L6+** — Vendor exit planning: что делать, когда vendor acquires / shuts down / radically изменяет pricing. Tested escape path для критичных vendors (не tabletop — реально проверенный).
+
+## Материалы
+
+### Книги
+
+- Betsy Beyer et al. (eds) — **[Site Reliability Engineering](https://sre.google/sre-book/managing-load/)** (O'Reilly, 2016). Не отдельная глава про vendors, но главы про «load balancing» / «addressing cascading failures» содержат принципы, применимые к vendor incidents (graceful degradation, criticality levels).
+- Mike Loukides, J. R. Storment, Mike Fuller — **[Cloud FinOps](https://www.finops.org/introduction/what-is-finops/)** (O'Reilly, 2nd ed., 2023). Не reliability-focused, но фундамент про vendor relationship management с финансово-операционной стороны. Полезно для границ ответственности SRE ↔ Procurement.
+- Will Larson — **[Staff Engineer](https://staffeng.com/)** (2021). Раздел про strategic decisions — vendor selection и concentration risk обсуждаются как пример типичного strategic call для staff IC.
+
+### Статьи и доклады
+
+- Cloudflare — **[Cloudflare outage on June 21, 2022](https://blog.cloudflare.com/cloudflare-outage-on-june-21-2022/)** и **[July 2 2019 outage post-mortem](https://blog.cloudflare.com/cloudflare-outage/)**. Главный публичный кейс — см. ниже.
+- Fastly — **[Summary of June 8, 2021 outage](https://www.fastly.com/blog/summary-of-june-8-2021-outage)**. Customer configuration change на Fastly side, который положил большой кусок интернета (NYT, Reddit, Twitch, UK gov). Хороший случай для playbook discussion.
+- AWS — **[Summary of the AWS Service Event in the US-EAST-1 Region, December 7 2021](https://aws.amazon.com/message/12721/)**. Связанный кейс: AWS как concentrated vendor; что значит «AWS down».
+- **[CrowdStrike outage of July 19, 2024](https://www.crowdstrike.com/falcon-content-update-remediation-and-guidance-hub/)**. Software vendor (security agent), не infrastructure vendor — но показательный кейс того, как vendor change может вывести из строя global IT.
+- **[Status Page Aggregators](https://stspg.io/)** и **[Atlassian Statuspage](https://www.atlassian.com/software/statuspage)**. Не статья, но pointer к infrastructure для vendor monitoring.
+
+### Инструменты
+
+- **Vendor inventory in repo / Notion** — самый базовый и самый часто пропускаемый инструмент. Markdown table: vendor / SLA / criticality / SLO impact / fallback / playbook link / contract renewal date. По моим наблюдениям, разница между командами с workingским vendor management и без — наличие этой таблицы.
+- **[StatusGator](https://statusgator.com/) / [IsDown](https://isdown.app/)** — aggregators status pages внешних vendors; sends alerts при vendor incident. Полезны для команд с десятками SaaS vendors.
+- **Synthetic monitoring (Datadog Synthetics / [Checkly](https://www.checklyhq.com/))** — проактивная проверка vendor endpoint health; ловит partial degradation раньше public status update.
+- **[Cloudflare Workers](https://workers.cloudflare.com/) / multi-CDN configuration** — практический инструмент redundancy для CDN tier. Один из немногих vendor-types, где multi-vendor реально работает.
+- **Анти-инструмент:** «vendor SLA в PDF контракта, который никто не читал». Если SLA не trackable / measurable / actionable — её эффективно нет.
+
+## Best practices
+
+Главный публичный кейс — **Cloudflare outage, July 2, 2019** (примерно 30 минут, ~50% всего HTTP-трафика интернета affected). Регулярное expression в WAF rule вызвало CPU exhaustion на edge serverах; ошибка попала в production без catching в pre-prod environments. **Что показал инцидент:** даже компании уровня Reddit, Twitch, Discord были effectively down, потому что Cloudflare — concentrated single point of failure для half of internet. Я регулярно вижу команды, у которых «у нас Cloudflare» как полное answer на вопрос «что у вас по DDoS / DNS / CDN», без понимания, что **vendor concentration** — это reliability risk, и в день Cloudflare outage любая redundancy на собственной инфраструктуре уже бесполезна. Это не аргумент против Cloudflare — это аргумент за **vendor incident playbook**: что мы делаем (degraded mode? read-only? bypass CDN?), когда vendor up за пределами нашего контроля.
+
+**Короткие правила:**
+
+- **Vendor inventory обязательна.** Без явного списка critical vendors с SLA / criticality / SLO impact — discussions держатся «в голове». Inventory living: PR при добавлении / удалении vendor.
+- **Composite SLO math явная.** «Наш SLO — 99.95%» при зависимости от vendor 99.9% без redundancy — математически невозможно. Либо redundancy, либо honest 99.9% (или ниже), либо явно accepted budget consumption на vendor side.
+- **Vendor incident playbook для критичных vendors.** «Что мы делаем, когда Cloudflare / AWS region / Stripe down» — конкретные steps, не «свяжемся с support». Tested в game day минимум раз в год.
+
+Подробнее:
+
+**Concentration risk vs operational simplicity — главный trade-off.** Single vendor (AWS-only / Cloudflare-only / Stripe-only) — operational simplicity, но full exposure to их incidents. Multi-vendor — снижает single-point-of-failure, но требует 2x ops effort, complex routing, payment redundancy и т.д. По моим наблюдениям, разумная граница: для **infrastructure tier** (cloud, DNS, CDN, payment) — multi-vendor оправдан для критичных компаний; для **operational tier** (observability, error tracking, communication tools) — single vendor обычно ОК с явным fallback. Конкретный baseline зависит от business criticality и customer-facing SLO.
+
+**Vendor SLA — нижняя граница, не expectation.** Реальный uptime обычно лучше contractual SLA (vendor consérves credit budget), но в год outage случается. SLO planning должен ассумировать SLA, не observed; иначе любой compliant vendor incident сжигает наш бюджет, и нам нечем покрыть собственные инциденты. Это базовая дисциплина, которую часто откладывают.
+
+**Vendor exit — не theoretical exercise.** Я регулярно вижу команды, у которых «vendor lock-in» обсуждается на ADR, но никогда не тестируется. Tested escape path для критичных vendors — это раз в 1–2 года прокат миграции хотя бы для одного non-critical сервиса между vendors. Без actual experience migration vendor exit — это wish, не plan. Особенно касается auth (Auth0 ↔ Okta ↔ Cognito), payment (Stripe ↔ Adyen ↔ Braintree), observability (Datadog ↔ New Relic ↔ Grafana Cloud).
+
+**Status page checking — automated, не manual.** Я регулярно вижу команды, у которых процесс «vendor incident detection» = «кто-то заметил в Slack» / «увидели на Twitter». Это late signal. Healthy подход: subscribe на vendor status RSS / webhook / API; integrate в свой incident management. Время от vendor announcement до собственного incident response — должно быть минуты, не десятки минут.
+
+**Annual vendor review ritual.** Раз в год — review portfolio: какие vendors используем (некоторые забыты), какие fees растут disproportionate to value, какие vendor SLA не соответствуют наблюдаемой uptime, какие contracts renewing (negotiation window), какие vendors консолидировали (M&A risk). Без ritual portfolio становится bag of accumulated decisions без revisit.
+
+## Связанные листья
+
+- **[Cost Management](/The-Way-of-SRE/leaves/engineering/cost-management/)** — vendor portfolio — крупный share cost bill; vendor commitment strategy (reserved capacity, multi-year contracts) — часть cost optimization.
+- **[SLO Engineering](/The-Way-of-SRE/leaves/engineering/slo-engineering/)** — composite SLO math: own SLO = product (vendor SLAs × own reliability). Vendor SLA — input для honest SLO commitment.
+- **[Capacity Planning](/The-Way-of-SRE/leaves/engineering/capacity-planning/)** — vendor quotas, lead time для scaling, concentration risk в одном vendor region.
+- **[Supply Chain Security](/The-Way-of-SRE/leaves/practices/supply-chain-security/)** — security-side vendor risk (CVE, SBOM, signed artifacts); этот лист — reliability-side. Соседние практики с общим vendor inventory.
+- **[Service Ownership](/The-Way-of-SRE/leaves/culture/service-ownership/)** — service catalog содержит upstream vendor dependencies; ownership of vendor relationship — explicit.
+- **[Incident Response](/The-Way-of-SRE/leaves/practices/incident-response/)** — vendor incident — отдельный класс incident; IC immediately checks vendor status в первые 5 минут.
+- **[Resilience Patterns](/The-Way-of-SRE/leaves/engineering/resilience-patterns/)** — graceful degradation для vendor unavailability: cached responses, fallback providers, degraded mode.
+- **[Architecture Decision Records](/The-Way-of-SRE/leaves/practices/architecture-decision-records/)** — vendor selection — типичный ADR; концентрация vs diversification — recurring decision.
+
+## Открытые вопросы
+
+- **Multi-Cloud Strategy** *(TBD)* — когда multi-cloud оправдан, когда anti-pattern; пересечение с capacity planning и cost management.
+- **Vendor Concentration Metrics** *(TBD)* — как количественно мерить vendor concentration risk (% of revenue / % of critical paths / blast radius).
+- **Open-source Dependencies как «vendor»** — semi-vendor relationships (Linux distro, k8s, PostgreSQL, etc); похожие governance вопросы, разный контекст.
+- **Vendor Negotiation Tactics** — engineering-сторона переговоров (technical evidence для лучших terms); пересечение с procurement role.
+- **Composite SLO Methodology** *(TBD)* — формальный math для multi-vendor multi-dependency SLO; отдельный лист.
+- Я не уверен, какая **минимальная granularity** vendor inventory правильна (на уровне vendor / на уровне отдельных endpoints / на уровне feature). Если у вас есть рабочая модель — расскажите через PR.

--- a/src/content/docs/sre-engineering.mdx
+++ b/src/content/docs/sre-engineering.mdx
@@ -19,7 +19,7 @@ import BranchView from '../../components/BranchView.astro';
 
 Построение и поддержка систем наблюдаемости: метрики, логи, трейсы (три столпа observability). Включает dashboards, alerting-стратегии и SLI-based мониторинг.
 
-**L2-концепты:** Metrics · Logging · Distributed Tracing · SLI-based Alerting · End-User Monitoring
+**L2-концепты:** Metrics · Logging · Distributed Tracing · SLI-based Alerting · Symptom vs Cause Alerting · End-User Monitoring
 
 ### Reliability Engineering
 
@@ -65,4 +65,4 @@ import BranchView from '../../components/BranchView.astro';
 
 ---
 
-Бюджет узлов: 1 корень + 8 L1 + 32 L2 = **41 узел** (в пределах политики `≤ 80` на проект).
+Бюджет узлов: 1 корень + 8 L1 + 33 L2 = **42 узла** (в пределах политики `≤ 80` на проект).

--- a/src/content/docs/sre-practices.mdx
+++ b/src/content/docs/sre-practices.mdx
@@ -29,7 +29,7 @@ import BranchView from '../../components/BranchView.astro';
 
 Безопасное управление изменениями в production: production readiness review, progressive delivery, rollback-стратегии, error budget gating, оценка риска изменений.
 
-**L2-концепты:** Production Readiness Review · Progressive Delivery · Rollback Strategy · Error Budget Gating · Change Risk Assessment
+**L2-концепты:** Production Readiness Review · Progressive Delivery · Change Governance · Rollback Strategy · Error Budget Gating · Change Risk Assessment
 
 ### Information Security
 
@@ -55,6 +55,12 @@ import BranchView from '../../components/BranchView.astro';
 
 **L2-концепты:** People Management · Setting Goals · Psychological Safety · Performance Conversations
 
+### Sourcing
+
+Управление engineering-зависимостями от внешних сервисов: vendor inventory, SLO impact, concentration risk, vendor incident playbook, exit planning. Граничит с procurement / finance, но фокус — на reliability impact и operational readiness.
+
+**L2-концепты:** Vendor Inventory · Vendor SLO Math · Concentration Risk · Vendor Incident Playbook · Exit Planning
+
 ---
 
-Бюджет узлов: 1 корень + 7 L1 + 32 L2 = **40 узлов**.
+Бюджет узлов: 1 корень + 8 L1 + 38 L2 = **47 узлов**.

--- a/src/data/roadmap.ts
+++ b/src/data/roadmap.ts
@@ -167,6 +167,11 @@ export const roadmap: Roadmap = {
               href: '/leaves/engineering/sli-based-alerting/',
             },
             {
+              id: 'symptom-vs-cause-alerting',
+              label: 'Symptom vs Cause Alerting',
+              href: '/leaves/engineering/symptom-vs-cause-alerting/',
+            },
+            {
               id: 'alert-fatigue-management',
               label: 'Alert Fatigue Management',
               href: '/leaves/engineering/alert-fatigue-management/',
@@ -354,6 +359,11 @@ export const roadmap: Roadmap = {
               label: 'Progressive Delivery',
               href: '/leaves/practices/progressive-delivery/',
             },
+            {
+              id: 'change-governance',
+              label: 'Change Governance',
+              href: '/leaves/practices/change-governance/',
+            },
           ],
         },
         {
@@ -416,6 +426,18 @@ export const roadmap: Roadmap = {
               id: 'one-on-ones',
               label: 'One-on-Ones',
               href: '/leaves/practices/one-on-ones/',
+            },
+          ],
+        },
+        {
+          id: 'sourcing',
+          label: 'Sourcing',
+          priority: 'mandatory',
+          leaves: [
+            {
+              id: 'vendor-management',
+              label: 'Vendor Management',
+              href: '/leaves/practices/vendor-management/',
             },
           ],
         },


### PR DESCRIPTION
## Summary

Вторая батч из изначального плана новых листьев. Закрывает явные структурные пробелы в Observability и Change Management, добавляет новую ветвь Sourcing.

**Новые листья:**

- **engineering/symptom-vs-cause-alerting** — дисциплина alert design: page на то, что чувствует пользователь (golden signals: latency / errors / traffic / saturation), а не на причины. Multi-burn-rate, quarterly alert portfolio review, black-box vs white-box. Публичный кейс: Rob Ewaschuk «My Philosophy on Alerting» (Google internal, 2014) как первоисточник принципа.
- **practices/change-governance** — дисциплина границ изменения в production: change classification (standard / normal / emergency), PRR как gate, freeze policy с whitelist, error budget gating. Публичный кейс: Knight Capital Group, август 2012 ($440M потеря за 45 минут из-за deploy-ошибки).
- **practices/vendor-management** — engineering-практика управления внешними зависимостями: vendor inventory, composite SLO math, concentration risk, vendor incident playbook, exit planning. Публичный кейс: Cloudflare outage 2 июля 2019 (regex CPU exhaustion, ~50% HTTP-трафика интернета affected). **Новый L1 \`Sourcing\`** под Practices (8 L1, бюджет узлов 40 → 47).

**Размещение по L1:**

- Engineering / Observability / Symptom vs Cause Alerting (рядом с SLI-based + Alert Fatigue — закрывает alert-design триаду)
- Practices / Change Management / Change Governance (рядом с Progressive Delivery — *policy* + *техника* deployment)
- Practices / *Sourcing* (NEW) / Vendor Management

**Cross-ссылки в смежных листьях** — заменены 5 TBD-маркеров на реальные ссылки:
- \`sli-based-alerting\`, \`alert-fatigue-management\` → \`symptom-vs-cause-alerting\`
- \`progressive-delivery\`, \`ci-cd\`, \`dev-team-partnership\` → \`change-governance\` (был Pre-Deployment Review / Production Readiness Review TBD)
- \`service-ownership\`, \`supply-chain-security\`, \`slo-engineering\` → \`vendor-management\`
- В \`service-ownership\` свёрнут TBD-список Cost / Vendor / Change Governance — все три теперь существуют как листья

**Обновлено:**
- \`astro.config.mjs\` sidebar — 3 новых пункта в правильных местах
- \`src/data/roadmap.ts\` — 2 новых leaf-узла в существующих L1 + новый L1 \`Sourcing\`
- \`sre-engineering.mdx\` — L2-список Observability +Symptom vs Cause Alerting, счётчик узлов 41→42
- \`sre-practices.mdx\` — L2-список Change Management +Change Governance, новый L1 Sourcing, счётчик узлов 40→47
- \`README.md\` — Engineering 15→16, Practices 15→17 (всего: 38→41 лист)

## Test plan

- [x] \`npx astro build\` — clean, 51 страница без ошибок
- [x] 3 новых leaf-страницы строятся: \`/leaves/engineering/symptom-vs-cause-alerting/\`, \`/leaves/practices/change-governance/\`, \`/leaves/practices/vendor-management/\`
- [ ] Визуально проверить sidebar (особенно: новый L1 Sourcing с Vendor Management в Practices)
- [ ] Проверить отсутствие битых внутренних ссылок (5 TBD → реальные)
- [ ] \`BranchView\` корректно рендерит новый L1 \`Sourcing\` в \`/sre-practices/\`
- [ ] Проверить, что в Observability теперь видна вся alert-design триада