### PR TITLE
feat(leaves): batch-3 — Shell & CLI Craft, Performance & Profiling, Operating Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ graph LR
 ```
 
 - **[SRE Culture](https://jtprogru.github.io/The-Way-of-SRE/sre-culture/)** — нормы, отношения, обмен опытом. Главный объект — люди и нормы. **8 листьев** на полной глубине.
-- **[SRE Engineering](https://jtprogru.github.io/The-Way-of-SRE/sre-engineering/)** — технические компетенции и стек. Главный объект — системы. **16 листьев** на полной глубине.
+- **[SRE Engineering](https://jtprogru.github.io/The-Way-of-SRE/sre-engineering/)** — технические компетенции и стек. Главный объект — системы. **19 листьев** на полной глубине.
 - **[SRE Practices](https://jtprogru.github.io/The-Way-of-SRE/sre-practices/)** — операционные процессы и ритуалы. Главный объект — процесс. **17 листьев** на полной глубине.
 
 Принцип разделения ветвей, политика контроля детализации, оси priority и SFIA — в [Методологии](https://jtprogru.github.io/The-Way-of-SRE/methodology/).

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -85,7 +85,9 @@ export default defineConfig({
                 { label: 'Resilience Patterns', link: '/leaves/engineering/resilience-patterns/' },
                 { label: 'Chaos Engineering', link: '/leaves/engineering/chaos-engineering/' },
                 { label: 'Networking', link: '/leaves/engineering/networking/' },
+                { label: 'Operating Systems', link: '/leaves/engineering/operating-systems/' },
                 { label: 'Programming Languages', link: '/leaves/engineering/programming-languages/' },
+                { label: 'Shell & CLI Craft', link: '/leaves/engineering/shell-cli-craft/' },
                 { label: 'CI/CD', link: '/leaves/engineering/ci-cd/' },
                 { label: 'Test Strategy', link: '/leaves/engineering/test-strategy/' },
                 { label: 'Infrastructure as Code', link: '/leaves/engineering/infrastructure-as-code/' },
@@ -93,6 +95,7 @@ export default defineConfig({
                 { label: 'Toil Tracking', link: '/leaves/engineering/toil-tracking/' },
                 { label: 'Backup & Restore', link: '/leaves/engineering/backup-restore/' },
                 { label: 'Cost Management', link: '/leaves/engineering/cost-management/' },
+                { label: 'Performance & Profiling', link: '/leaves/engineering/performance-profiling/' },
               ],
             },
             {

--- a/src/content/docs/leaves/engineering/capacity-planning.md
+++ b/src/content/docs/leaves/engineering/capacity-planning.md
@@ -71,6 +71,7 @@ description: Прогнозирование потребности в ресур
 - **[Service Ownership](/The-Way-of-SRE/leaves/culture/service-ownership/)** — каталог сервиса содержит capacity-метаданные: текущий resource budget, forecast horizon, owner.
 - **[Incident Response](/The-Way-of-SRE/leaves/practices/incident-response/)** — capacity-induced incidents — отдельный класс с собственным response (emergency scale-up, traffic shed, criticality demotion).
 - **[Cost Management](/The-Way-of-SRE/leaves/engineering/cost-management/)** — capacity рассматривается с двух сторон: «хватит ли» (этот лист) и «во что обходится» (cost management). Forecast — один.
+- **[Performance & Profiling](/The-Way-of-SRE/leaves/engineering/performance-profiling/)** — две стороны ресурса: «хватит ли» (этот лист) и «правильно ли используем те, что есть» (profiling). Resource efficiency через profiling — input для capacity decisions.
 
 ## Открытые вопросы
 

--- a/src/content/docs/leaves/engineering/networking.md
+++ b/src/content/docs/leaves/engineering/networking.md
@@ -75,8 +75,8 @@ description: Сетевой стек как фундамент надёжнос�
 - **[Programming Languages](/The-Way-of-SRE/leaves/engineering/programming-languages/)** — реализация retries / circuit breaker / timeouts происходит в коде; знание сетевых библиотек языка — половина resilience-практики.
 - **[Incident Response](/The-Way-of-SRE/leaves/practices/incident-response/)** — сетевые инциденты (DNS, TLS, peer'ы, certs, mesh) — отдельный класс с собственным набором диагностических действий.
 - **[Runbooks](/The-Way-of-SRE/leaves/culture/runbooks/)** — runbook'и для типичных сетевых сценариев (cert expired, DNS resolver down, mesh control plane unhealthy).
+- **[Operating Systems](/The-Way-of-SRE/leaves/engineering/operating-systems/)** — kernel networking, TCP-стек ядра, network namespaces — соседняя по domain'у тема; границы пересекаются на `tcpdump` / `ss` / `conntrack` / namespaces.
 
 ## Открытые вопросы
 
 - **Resilience Patterns** уже выделены в отдельный лист под `Reliability Engineering`. Граница: Networking — про *сеть* как медиум; Resilience Patterns — про архитектурные паттерны устойчивости.
-- **Operating Systems** (kernel networking, TCP-стек ядра, network namespaces) — пограничная тема. Сейчас kernel-уровень упомянут в инструментах (`bpftrace`, `nftables`); отдельный лист возможен при углублении ветви.

--- a/src/content/docs/leaves/engineering/operating-systems.md
+++ b/src/content/docs/leaves/engineering/operating-systems.md
@@ -1,0 +1,102 @@
+---
+title: Operating Systems
+description: OS как SRE-инструмент — namespaces, cgroups, syscalls, page cache, network stack, eBPF; слой между процессом и железом
+---
+
+:::note[Метаданные листа]
+- **Ветвь:** Engineering
+- **Путь:** IT Infrastructure / Operating Systems
+- **SFIA-уровни:** 3, 4, 5, 6
+- **Приоритет:** Must Have
+- **Статус:** draft
+:::
+
+«У нас Kubernetes, kernel — это магия» — позиция, которая работает, пока инцидент не звучит как «pod жив, но не отвечает», «container OOM-killed при свободном RAM», «странный TCP timeout, который не воспроизводится в staging». В этот момент инженер без OS knowledge — заложник симптомов. Я регулярно вижу команды, которые держатся на 5 senior'ах с глубоким Linux-bg, и эти senior'ы становятся single point of failure для любого «странного» инцидента. Операционная система — это не «изучать kernel хобби»: это **слой между процессом и железом**, который нужно понимать, чтобы дебажить production. Namespaces / cgroups (на чём стоит Docker / k8s), syscalls (что процесс реально просит у kernel), page cache (почему `free` ничего не говорит про memory), network stack (где между приложением и сетью теряется пакет). eBPF в 2020-х превратился из niche-tech в обязательный observability layer — но без OS knowledge он magic, с — practical tool.
+
+Граница: [Networking](/The-Way-of-SRE/leaves/engineering/networking/) — про сетевой стек как отдельный домен; этот лист — про OS целиком (включая kernel network stack как частный случай). [Performance & Profiling](/The-Way-of-SRE/leaves/engineering/performance-profiling/) — *как мерить* perf; этот лист — *что мерить и почему так* (kernel context для USE method). [Shell & CLI Craft](/The-Way-of-SRE/leaves/engineering/shell-cli-craft/) — интерфейс к OS через terminal; этот лист — то, что под shell.
+
+## Что должен уметь
+
+Главный навык на уровне L4 — читать **`/proc`** как реальный source of truth для процесса: `/proc/[pid]/status`, `/proc/[pid]/maps`, `/proc/[pid]/limits`, `/proc/[pid]/fd/`. По моим наблюдениям, разница между debug'ом «процесс жив, но что-то с ним» — это разница между «знаю, что в /proc лежит» и «использую только `top` / `ps`». В incident под высоким стрессом первый прыгает в /proc сразу, второй стучится в kubernetes UI. Один день на reading `proc(5)` manpage и Reading the Linux Kernel — заметная разница для всех будущих on-call смен.
+
+- **L3** — Понимает processes / threads / fork / exec; разбирается в exit codes, signals (SIGKILL vs SIGTERM); читает `ps`, `top`, `htop`, `pgrep`, `kill`.
+- **L3** — Знает базовые file system concepts: inode, hard link vs symlink, mount points, basic permissions (`chmod`, `chown`); читает `df`, `du`, `lsof`.
+- **L4** — Различает **virtual memory vs RSS vs working set**; знает, что show `top` (`VIRT` / `RES` / `SHR`) и почему `free` показывает «used» иначе, чем интуиция. Понимает page cache и почему «high used memory» — обычно норма.
+- **L4** — Использует **`strace`** для syscall debugging: `strace -f -e trace=network nginx`, `strace -p PID`. Понимает overhead и применяет осторожно в prod.
+- **L4** — Понимает **namespaces и cgroups**: что Docker / k8s container — это процесс с собственным mount/network/pid namespace и cgroup limits, а не VM. Знает, как читать `/proc/[pid]/cgroup`, `/sys/fs/cgroup/`.
+- **L4** — Различает signals: `SIGTERM` (graceful), `SIGKILL` (kernel kill), `SIGSEGV` (programming bug); знает, что OOM-killer выбирает victim и как читать `dmesg` для post-mortem.
+- **L5** — Применяет **eBPF / bpftrace** для production observability: `execsnoop`, `tcplife`, `runqlat`, `biolatency`. Понимает, что eBPF не magic — это compiled bytecode in kernel sandbox.
+- **L5** — Знает kernel scheduling basics: CFS, run queue, scheduler latency, NUMA affinity, hyper-threading effects.
+- **L5** — Debug containers без `docker exec`: `nsenter` в pid/net namespace, `cat /proc/[container-pid]/...`, attach к stuck container через kernel-level tools.
+- **L6+** — Tuning производственного OS: sysctl baseline (`net.core.somaxconn`, `vm.swappiness`, `fs.file-max`), kernel parameter rationale, аудит изменений после OS upgrades.
+- **L6+** — Реагирует на новые kernel CVE / features со знанием контекста: Spectre / Meltdown / Dirty Pipe (CVE-2022-0847), io_uring evolution, eBPF security model.
+
+## Материалы
+
+### Книги
+
+- Brendan Gregg — **[Systems Performance: Enterprise and the Cloud](https://www.brendangregg.com/systems-performance-2nd-edition-book.html)** (Addison-Wesley, 2-е изд., 2020). Не только perf, а целая mental model Linux internals. Главы 3–7 — observable OS-стороны. Если выбирать одну книгу для SRE — эту.
+- Brendan Gregg — **[BPF Performance Tools](https://www.brendangregg.com/bpf-performance-tools-book.html)** (Addison-Wesley, 2019). eBPF как новый класс OS observability; готовые tools (bcc-tools, bpftrace), которые работают в prod.
+- W. Richard Stevens, Stephen A. Rago — **[Advanced Programming in the UNIX Environment](https://www.amazon.com/Advanced-Programming-UNIX-Environment-3rd/dp/0321637739)** (Addison-Wesley, 3-е изд., 2013). Если хочется системного introduction в syscall layer / signals / IPC — этот канон. Не для линейного чтения, а для глав по теме.
+- Robert Love — **[Linux Kernel Development](https://rlove.org/)** (Addison-Wesley, 3-е изд., 2010). Введение в kernel architecture: scheduler, memory management, virtual filesystem. Не для writing kernel code — для понимания, что происходит «там, внутри».
+- Liz Rice — **[Container Security](https://www.oreilly.com/library/view/container-security/9781492056690/)** (O'Reilly, 2020). Несмотря на название — лучшее краткое introduction в namespaces / cgroups / capabilities / seccomp с точки зрения «как работает контейнер». Глава 4 «Containers vs Virtual Machines» — must-read.
+
+### Статьи и доклады
+
+- Brendan Gregg — **[Linux Performance](https://www.brendangregg.com/linuxperf.html)**. Living document с обновлениями; одна страница с tools list, methodologies, references. Главный публичный кейс — см. ниже.
+- Julia Evans — **[Wizard Zines on Linux](https://wizardzines.com/zines/)**. Серия short zines (Bite Size Linux, Container Networking, Bite Size Kubernetes) — лучший accessible introduction к Linux internals для тех, кто backed off from 1000-page books. По моим наблюдениям, чаще всего team-level «Linux fluency» расти именно через Julia's материалы.
+- Liz Rice — **[Why Container Security Matters](https://www.youtube.com/watch?v=8nVUbF8aJtw)** (KubeCon). 30 минут — namespaces / cgroups / capabilities в живом demo с `unshare`, `nsenter`.
+- **[The Linux Programming Interface (TLPI)](https://man7.org/tlpi/)** by Michael Kerrisk. Если книга Stevens / Rago слишком dense — это modern alternative с тем же scope. Доступна частично онлайн.
+
+### Инструменты
+
+- **`/proc`, `/sys`** — primary sources of truth. Каждый running process exposes огромную поверхность через `/proc/[pid]/`. По моим наблюдениям, разница между SRE-беглым и не-беглым в OS — это не книги, это привычка `cat /proc/...` как первый шаг debug.
+- **`strace` / `ltrace`** — syscall и library call tracing. `strace` overhead высокий (caution в prod), но в staging — обязательный tool для «что процесс реально делает».
+- **`perf`** (Linux native) — CPU profiling, hardware counters, scheduling events. Часть kernel; не требует install в современных дистрах.
+- **[bcc-tools](https://github.com/iovisor/bcc) / [bpftrace](https://bpftrace.org/)** — eBPF-based tools. Brendan Gregg's bcc-tools: `execsnoop`, `opensnoop`, `biolatency`, `tcplife`, `runqlat`. Read-only observability в prod без service restart.
+- **`nsenter`** — войти в namespace целевого процесса. `nsenter -t [pid] -n ss -tnlp` — посмотреть listening sockets внутри container'а без `docker exec`.
+- **`dmesg`** / **`journalctl`** — kernel ring buffer / systemd logs. OOM-killer messages, kernel panic, driver issues — здесь.
+- **`sysstat`** (`sar`, `iostat`, `mpstat`, `vmstat`) — classic system monitoring tools. Старые, но bedrock для baseline.
+- **[BCC's PostgreSQL probes / eBPF in production](https://github.com/iovisor/bcc)** — concrete examples production-grade eBPF.
+- **Анти-инструмент:** «всегда `docker exec` для дебага container'а». `docker exec` запускает новый shell в container — context отличается от target process; `nsenter` даёт actual view.
+
+## Best practices
+
+Главный публичный кейс — **Brendan Gregg's work at Netflix on Linux performance (2015–2020) и его публикации**. Gregg на десятилетие сделал eBPF / perf / flame graphs стандартом индустрии — не через product, а через **demonstration**: серия blog posts «Linux X: How CPU is really used», «60 seconds Linux performance analysis», «execsnoop saved my Saturday». Каждый пост — реальный production случай с командой, профилем, finding'ом, и fix'ом. Я регулярно вижу команды, которые знают слова «eBPF», «flame graph» — но не применяют их, потому что не видели demonstration. Gregg'овские посты — best resource именно для «как реально использовать», не «что это в теории». Один час чтения «60-second Linux Performance Analysis» — материал, который окупается каждый раз при «странном» инциденте.
+
+**Короткие правила:**
+
+- **OS — слой между процессом и железом, не commodity.** «У нас всё в k8s, OS не важен» — позиция, которая работает до первого нетривиального инцидента. Container — это процесс с namespaces / cgroups, kernel один на все pods на ноде; tuning одного worker'а влияет на соседей.
+- **`/proc` и `dmesg` — первый шаг при «странном» инциденте.** До UI, до dashboards, до Grafana — `cat /proc/[pid]/...`, `dmesg | tail -50`. Часто причина видна сразу.
+- **Sysctl не настраиваются «потому что в guide»**. Каждое изменение — explicit rationale в git commit / runbook. Без rationale через год никто не помнит, что и почему.
+
+Подробнее:
+
+**Container ≠ VM, и это формирует debug-стиль.** Distributing «container — облегчённая VM» создаёт неправильную mental model: внутри container ОЖИДАЮТ изоляции уровня VM, и удивляются, что один container может exhaust kernel resources хоста (file descriptors, conntrack table, ephemeral ports). Healthy model: container — это процесс в namespaces / cgroups, kernel общий, ресурсы могут shared в неочевидных местах. Я регулярно вижу инциденты типа «pod вылетел, но restart не помог» — потому что host-level resource exhausted, и любой новый pod на этом host попадёт в ту же проблему.
+
+**OOM-killer выбирает victim по `oom_score`, не «по фактическому usage».** Распространённая confusion: «у нас 32GB RAM, container ушёл OOM-killed в 2GB — kernel сошёл с ума». Реально: cgroup memory limit стоял 2GB, kernel honored limit. `dmesg` показывает exact details. Я регулярно вижу команды, которые не читают `dmesg` после OOM — и не понимают, что выбор victim'а — deterministic process с `/proc/[pid]/oom_score`.
+
+**eBPF — это не magic, это compiled bytecode в kernel sandbox.** Распространённое впечатление: «bpftrace показывает что-то и работает быстро — это магия». Реально: programmer пишет high-level script → компилится в BPF bytecode → kernel verifies safety → JIT-compiles в native → runs in kernel context. Knowing this — снимает страх «вдруг eBPF положит ноду». В production-ready BPF tools (bcc, bpftrace) verifier гарантирует safety: bounded loops, no unbounded memory, returns within time.
+
+**Kernel tuning без baseline — risk без upside.** Я регулярно вижу команды, которые скопировали 30 строк `sysctl` из forum-поста 2014 года в production. Часть параметров уже kernel default, часть — opposed to сегодняшнего workload, часть — legacy fixes для проблем, которых нет. Healthy approach: каждое изменение — обоснованное по profile / observed metric; tested в staging; git commit с rationale; revisit раз в год после kernel upgrade. Без этой дисциплины sysctl превращается в cargo-cult.
+
+**Reading `proc(5)` manpage окупается на годы.** `man 5 proc` — описание формата каждого файла в `/proc`. 200+ файлов на процесс, и большинство SRE знают ~5 из них. Один вечер чтения — и в debug появляется arsenal: `/proc/[pid]/status` (state, threads, signal masks), `/proc/[pid]/maps` (memory mapping, shared libs), `/proc/[pid]/io` (read/write bytes), `/proc/[pid]/wchan` (где процесс sleep'ит в kernel). По моим наблюдениям, разница между OS-беглым SRE и не — почти всегда `/proc`-fluency.
+
+## Связанные листья
+
+- **[Networking](/The-Way-of-SRE/leaves/engineering/networking/)** — kernel network stack — частный случай OS internals; TCP / sockets / netfilter / namespaces — overlap зоны.
+- **[Performance & Profiling](/The-Way-of-SRE/leaves/engineering/performance-profiling/)** — profiling tooling (perf, eBPF) — OS-level instruments; глубокий performance невозможен без OS knowledge.
+- **[Shell & CLI Craft](/The-Way-of-SRE/leaves/engineering/shell-cli-craft/)** — shell — primary interface к OS; беглость в одном требует беглости в другом.
+- **[Programming Languages](/The-Way-of-SRE/leaves/engineering/programming-languages/)** — language runtime sits on OS; GC pauses, scheduler interactions, syscall patterns — это intersection.
+- **[Capacity Planning](/The-Way-of-SRE/leaves/engineering/capacity-planning/)** — saturation indicators (run queue length, IO wait, page faults) — OS-level metrics.
+- **[Resilience Patterns](/The-Way-of-SRE/leaves/engineering/resilience-patterns/)** — health probes на OS-level (TCP listening?, process alive?, file descriptor exhaust?) — overlap.
+- **[Incident Response](/The-Way-of-SRE/leaves/practices/incident-response/)** — non-trivial incident часто требует OS-debugging; первая минута — `dmesg`, `/proc`, `nsenter`.
+
+## Открытые вопросы
+
+- **Containerization & Orchestration как отдельный лист** *(TBD)* — Docker / containerd / runc internals, k8s primitives, OCI specs. Соседняя тема под IT Infrastructure.
+- **Service Mesh патчит OS-layer** *(TBD)* — Envoy / Istio sidecar — что реально делают на networking stack. Соседняя тема.
+- **macOS / Windows как dev environment** — большинство OS-knowledge линейно переносится на Linux production; некоторые тонкости (file system semantics, signal handling) — другие.
+- **eBPF Production Readiness** *(TBD)* — best practices для writing custom eBPF programs (vs using pre-built tools); verifier limits, kernel version compatibility.
+- **kernel Tuning Patterns for k8s nodes** *(TBD)* — typical sysctl set для k8s-worker'ов; обоснование, не cargo-cult.
+- Я не уверен, какой **минимальный depth OS knowledge** достаточен для on-call в managed-k8s environment (EKS / GKE / AKS). Если у вас есть pragmatic floor — расскажите через PR.

--- a/src/content/docs/leaves/engineering/performance-profiling.md
+++ b/src/content/docs/leaves/engineering/performance-profiling.md
@@ -1,0 +1,99 @@
+---
+title: Performance & Profiling
+description: Измерение перед оптимизацией — pprof, perf, flame graphs, USE method; дисциплина против «оптимизирую то, что first comes to mind»
+---
+
+:::note[Метаданные листа]
+- **Ветвь:** Engineering
+- **Путь:** Programming / Scripting / Performance & Profiling
+- **SFIA-уровни:** 3, 4, 5, 6
+- **Приоритет:** Mandatory
+- **Статус:** draft
+:::
+
+«Сервис тормозит, нужно оптимизировать» — самая частая фраза, после которой инженер начинает менять код наугад. Performance & Profiling — это **дисциплина измерения перед оптимизацией**: запустить pprof / perf / flame graph, увидеть actual hotspots (не предполагаемые), и только потом трогать код. Я регулярно вижу циклы «оптимизировали неделю → сделали хуже» именно потому, что hotspot был не там, где казалось. Don Knuth известное «premature optimization is the root of all evil» — про это: оптимизация без измерения почти всегда трата времени. Brendan Gregg's flame graph (2011) и pprof из Google's gperftools — два самых видимых инструмента; USE method (Utilization / Saturation / Errors) — самая практичная methodology.
+
+Граница: [Capacity Planning](/The-Way-of-SRE/leaves/engineering/capacity-planning/) — «хватит ли ресурсов»; этот лист — «правильно ли используем те, что есть». [SLO Engineering](/The-Way-of-SRE/leaves/engineering/slo-engineering/) — *что* мерить (SLI как business-facing метрика); profiling — *как именно* копать, когда SLI деградировал. [Programming Languages](/The-Way-of-SRE/leaves/engineering/programming-languages/) — language-specific perf-tooling (pprof для Go, py-spy для Python); этот лист — universal methodology.
+
+## Что должен уметь
+
+Главный навык на уровне L4 — **измерять до того, как трогать код**. По моим наблюдениям, разница между junior'ом и senior'ом в perf-задачах — не в знании tooling (Гугл найдёт), а в дисциплине «сначала flame graph, потом hypothesis». Junior читает код, формулирует hypothesis «вот тут O(n²)», переписывает — оказывается, hotspot в другом месте. Senior запускает profile, смотрит actual distribution, потом формулирует hypothesis. Это разница в одну привычку, которая экономит часы каждую неделю.
+
+- **L3** — Знает, что профилировать (CPU / memory / I/O / network); понимает разницу между sampling profilers (perf, async-profiler) и instrumenting profilers (pprof для Go runtime); запускает базовый pprof / py-spy / async-profiler.
+- **L3** — Читает flame graph: где burning width (количество samples), где stack depth, какие функции в top.
+- **L4** — Применяет **USE method**: для каждого ресурса (CPU, memory, disk, network) — utilization (% времени busy), saturation (queue depth / wait time), errors (drop / retransmit). Brendan Gregg's checklist — стандартная отправная точка.
+- **L4** — Профилирует **перед** изменением кода, не **после**. Формулирует optimization hypothesis на основе measured data, проверяет hypothesis повторным profile.
+- **L4** — Знает classic perf anti-patterns: N+1 queries, hot lock contention, unbounded GC, allocation in hot loop, memory leak vs memory growth, false sharing.
+- **L5** — Применяет **continuous profiling** в production (Pyroscope / Parca / Grafana Cloud Profiles / Datadog Continuous Profiler): regression detection, on-demand drill-down, без impact на сервис.
+- **L5** — Использует **differential profiling**: snapshot до и после release, сравнение через `pprof -base`. Каждый release — потенциальный perf regression; без differential profiling regressions копятся незаметно.
+- **L5** — Профилирует **production**, не «локально на ноуте». Microbenchmarks и synthetic load дают неправильные hotspots в 50% случаев — locality, GC pressure, IO patterns отличаются.
+- **L6+** — Строит perf budget / latency budget программу: каждый сервис имеет latency budget по компонентам (network / CPU / IO / downstream), tracked over time, regression alerts при отклонении.
+- **L6+** — Связывает performance discipline с SLO program: profile-driven optimization targets SLI deltas, а не «общую скорость»; resource efficiency как explicit metric (cost-per-request, см. [Cost Management](/The-Way-of-SRE/leaves/engineering/cost-management/)).
+
+## Материалы
+
+### Книги
+
+- Brendan Gregg — **[Systems Performance: Enterprise and the Cloud](https://www.brendangregg.com/systems-performance-2nd-edition-book.html)** (Addison-Wesley, 2-е изд., 2020). Каноническая книга. Если выбирать одну — эту. USE method, методологии, конкретные tools для Linux. 800+ страниц, но используется главами, не линейно.
+- Brendan Gregg — **[BPF Performance Tools](https://www.brendangregg.com/bpf-performance-tools-book.html)** (Addison-Wesley, 2019). eBPF-revolution в profiling — следующий шаг после classical perf. Practical, с готовыми инструментами (bcc-tools).
+- Daniel J. Bernstein — **[The Sound and the Furby (qmail anti-spam talk transcript)](https://cr.yp.to/talks/2003.03.21/slides.pdf)** (2003). Не perf-книга, но фундаментальное эссе: «before optimizing X, prove X matters». Подкладывает philosophical baseline.
+- Andrei Alexandrescu — **[Modern C++ Design](https://erdani.com/index.php/books/modern-c-design/)** (Addison-Wesley, 2001). C++-specific, но раздел про template-based optimization — про дисциплину «measure first».
+
+### Статьи и доклады
+
+- Brendan Gregg — **[Flame Graphs](https://www.brendangregg.com/flamegraphs.html)** (2011 — настоящее время). Главный практический tool. Полностью описан в одной странице. Если выбирать одну статью — эту. Главный публичный кейс — см. ниже.
+- Brendan Gregg — **[The USE Method](https://www.brendangregg.com/usemethod.html)**. Канонический systematic подход. «Solves 80% of server issues with 5% of the effort». Применимо к любой системе.
+- Google — **[pprof README](https://github.com/google/pprof/blob/main/doc/README.md)**. Документация tool'а — лучший introduction в profile analysis вообще.
+- Netflix Tech Blog — **[Java in Flames](https://netflixtechblog.com/java-in-flames-e763b3d32166)** (2015). Showcase того, как flame graph меняет debug-стиль; classic.
+- Charity Majors — **[Observability Is a Many Splendored Definition](https://charity.wtf/2020/03/03/observability-is-a-many-splendored-thing/)**. Не perf-статья прямо, но контекст: continuous profiling как часть observability stack, не отдельный остров.
+
+### Инструменты
+
+- **[pprof](https://github.com/google/pprof)** (Go native, есть библиотеки для большинства языков) — де-факто стандарт для CPU / memory / blocking / mutex profiling. По моим наблюдениям, чаще всего инфраструктура «`/debug/pprof/` endpoint» — первое, что подключают к новому Go-сервису.
+- **[perf](https://perf.wiki.kernel.org/)** (Linux native) — kernel-level profiling: `perf record` / `perf report`. CPU profiling на любом языке через sampling; обязательно для serious perf work.
+- **[eBPF / bcc-tools / bpftrace](https://github.com/iovisor/bcc)** — kernel observability без instrumentation. Brendan Gregg's bcc-tools — готовые scripts: `execsnoop`, `biolatency`, `tcplife`, `runqlat`. Когда нужно «что именно делает kernel прямо сейчас» — это инструмент.
+- **[async-profiler](https://github.com/async-profiler/async-profiler)** — JVM sampling profiler, де-факто стандарт для Java. Поддерживает CPU / allocation / lock-contention.
+- **[py-spy](https://github.com/benfred/py-spy)** — Python sampling profiler, runs out-of-process. Без overhead на target service.
+- **[Pyroscope](https://pyroscope.io/)** / **[Parca](https://www.parca.dev/)** / **[Grafana Cloud Profiles](https://grafana.com/docs/grafana-cloud/monitor-applications/profiles/)** — continuous profiling platforms. Pyroscope (теперь часть Grafana) — open-source; Datadog Continuous Profiler — коммерческий. По моим наблюдениям, чаще всего команды берут Pyroscope для self-hosted, Datadog/New Relic — если уже там.
+- **[FlameGraph](https://github.com/brendangregg/FlameGraph)** (Brendan Gregg) — генератор flame graphs из perf output. Командная строка, ничего лишнего.
+- **Анти-инструмент:** «оптимизация по интуиции без profile». Это не инструмент, это antipattern; самый частый источник «оптимизировали → сделали хуже».
+
+## Best practices
+
+Главный публичный кейс — **Brendan Gregg's CPU flame graph work at Netflix (~2014–2015)**. Gregg опубликовал серию blog posts: одна команда жаловалась на «Java тормозит»; flame graph за 30 секунд показал, что 90% CPU в одной regex-evaluation внутри logger'а, не в business logic. Одно изменение конфигурации логгера дало 8x speedup. Это canonical пример того, как flame graph **меняет рамку дебага**: вместо «давайте перепишем X на Y», вопрос становится «где actual hotspot и стоит ли его трогать». Я регулярно вижу команды, которые читали про flame graph, но не использовали его в работе — и решают perf-задачи через code review / hypothesis-driven changes. Flame graph не требует expertise; требует только привычки запустить его раньше, чем редактор кода.
+
+**Короткие правила:**
+
+- **Profile до изменения, profile после.** Без before/after — это не optimization, это случайный change. Differential profiling (`pprof -base` / Pyroscope diff view) — обязательная дисциплина.
+- **Profile production, не local microbenchmark.** Locality, GC pressure, allocator behavior, IO patterns — всё другое. Microbenchmark — для алгоритмических hot loops; production profile — для system-level.
+- **USE method как первый pass.** При непонятном «тормозит» — пробежать USE по CPU / memory / disk / network перед уходом в код. 80% инцидентов resolved на этом шаге.
+
+Подробнее:
+
+**Sampling vs instrumenting — выбор по контексту.** Sampling profilers (perf, async-profiler, py-spy) — low overhead, можно запускать на prod; не видят функции, которые быстро выполняются много раз (если sample interval больше function duration). Instrumenting profilers (pprof Go runtime, gprof) — точные counts / timings, но overhead до 30%+. Для prod use sampling; для targeted analysis отдельного workflow — instrumenting в staging. По моим наблюдениям, типовая ошибка — пытаться использовать instrumenting на prod и получать неправильную картину из-за overhead-induced contention.
+
+**Flame graph читать справа налево, не сверху вниз.** Распространённая ошибка чтения: ищут «top function» на flame graph. Top — это «непосредственно where CPU is now», но это часто mundane (memory allocator, GC, stdlib). Ширина function на любом уровне — % CPU, проведённого «в этой функции и её callees». Сначала смотреть **wide functions in the middle** (это main hotspots) — потом drill down. Несколько `--reverse` graphs (bottom-up) дополняют сверху-вниз picture.
+
+**Continuous profiling меняет cadence perf-work.** Classical approach — «когда что-то сломается, профилируй». Continuous — «всегда профилируешь, regression detection автоматический». Разница: regression от release ловится в день release, не через 2 месяца, когда уже три release легло поверх. По моим наблюдениям, разница между здоровой и нездоровой perf-culture — наличие continuous profiling; не tool sophistication.
+
+**Latency budget per component — практический шаг от SLO к profiling.** Сервис обещает 99-й percentile latency < 100ms. Куда уходит этот бюджет: 20ms — network round-trip, 5ms — JSON parsing, 30ms — DB query, 40ms — business logic, 5ms — response serialization. Когда какой-то компонент превышает свой sub-budget, profile-driven debugging имеет очевидную точку входа. Без budget perf-debug становится поиском в темноте.
+
+**Memory profiling — про allocation rate, не total RSS.** RSS растёт у любого работающего процесса (caches, GC heap, mmap). Hot question — **allocation rate**: сколько MB/s аллокируется. Высокий allocation rate → GC pressure → latency spikes. pprof's `alloc_objects` / `alloc_space` показывает именно это. Я регулярно вижу команды, которые мерят `RSS over time` и не понимают, почему «memory вроде не растёт, а latency дёргается» — потому что allocation churn выше capacity GC.
+
+## Связанные листья
+
+- **[Programming Languages](/The-Way-of-SRE/leaves/engineering/programming-languages/)** — каждый язык имеет own perf-tooling (pprof для Go, async-profiler для JVM, py-spy для Python); фундамент языка определяет, какие perf-проблемы вообще возможны (GC pressure, lock contention).
+- **[Shell & CLI Craft](/The-Way-of-SRE/leaves/engineering/shell-cli-craft/)** — `perf`, `strace`, `bpftrace` — CLI-инструменты; performance work требует беглости в shell.
+- **[Operating Systems](/The-Way-of-SRE/leaves/engineering/operating-systems/)** — kernel-level profiling (eBPF, perf events, ftrace) — это OS-внутренности; performance L5+ невозможен без понимания OS.
+- **[Capacity Planning](/The-Way-of-SRE/leaves/engineering/capacity-planning/)** — «хватит ли ресурсов» (capacity) vs «правильно ли используем» (profiling) — две стороны одной задачи.
+- **[SLO Engineering](/The-Way-of-SRE/leaves/engineering/slo-engineering/)** — SLI определяет, что мерить; profiling — как именно копать, когда SLI деградировал.
+- **[Cost Management](/The-Way-of-SRE/leaves/engineering/cost-management/)** — resource efficiency через profiling — input для cost-aware decisions; cost-per-request reflects perf engineering quality.
+- **[Networking](/The-Way-of-SRE/leaves/engineering/networking/)** — network-side profiling (tcpdump, packet capture, mtr) — отдельная под-область с собственными tools.
+
+## Открытые вопросы
+
+- **Continuous Profiling Adoption Strategy** *(TBD)* — как внедрить в команду, которая работает без него; что мерить как success.
+- **DB Performance Tuning** *(TBD)* — index design, query plans, connection pooling, vacuum/compaction — соседняя practice под Database Reliability.
+- **Front-end Performance** *(TBD)* — Core Web Vitals, RUM, browser profiling. Не SRE-traditional, но в продуктовых командах SRE часто партнёрит.
+- **Microbenchmark Discipline** *(TBD)* — JMH (Java), `testing.B` (Go), pytest-benchmark (Python). Как избежать стандартных pitfalls (warm-up, statistical noise, dead-code elimination).
+- Я не уверен, как **правильно делать ML-profiling** (training step time vs GPU utilization). Если у вас есть practice — расскажите через PR.

--- a/src/content/docs/leaves/engineering/programming-languages.md
+++ b/src/content/docs/leaves/engineering/programming-languages.md
@@ -64,7 +64,7 @@ description: SRE пишет код — один-два языка на уров�
 
 **SRE-код — это production-код, а не «временный скрипт».** Это правило ломается чаще всего вокруг shell-скриптов. Я наблюдаю типичный паттерн: трёхлетний bash-скрипт в crontab упал молча, отдал NaN в одну из метрик capacity planning, об этом узнали через две недели, когда поломался дашборд. Скрипт не был покрыт тестами, не запускался в CI, не имел владельца — потому что «временный». Если код запускается на проде регулярно — он живёт по тем же правилам, что код продуктовой команды: репозиторий, тесты, code review, versioning, наблюдаемость своего же tooling.
 
-**Shell-уверенность — отдельная инвестиция, не «приложение к Go».** Хороший Go не заменяет умения написать `for f in $(...); do ...; done`, прочитать `kubectl logs ... | jq | grep` и парсить вывод утилит. В on-call это пишется ежедневно, и плохой bash тратит здесь больше времени, чем плохой Go в коде сервиса. Соседний лист `Shell & CLI Craft` *(TBD)* — про это отдельно.
+**Shell-уверенность — отдельная инвестиция, не «приложение к Go».** Хороший Go не заменяет умения написать `for f in $(...); do ...; done`, прочитать `kubectl logs ... | jq | grep` и парсить вывод утилит. В on-call это пишется ежедневно, и плохой bash тратит здесь больше времени, чем плохой Go в коде сервиса. Соседний лист — [Shell & CLI Craft](/The-Way-of-SRE/leaves/engineering/shell-cli-craft/).
 
 **Чтение чужого кода — главный навык SRE.** SRE поддерживает чужие сервисы, и читать чужой код приходится больше, чем писать свой. Я наблюдаю чёткое разделение между сильными и слабыми инженерами по этому критерию: сильные — «прочитаю код, чтобы понять, потом задам вопрос автору»; слабые — «вызову автора при каждом непонятном поведении, не открывая код». Регулярная практика — code review соседних сервисов, walkthrough legacy-кода с тех. лидами, шаг «понять прежде, чем менять» — обязателен.
 
@@ -75,9 +75,11 @@ description: SRE пишет код — один-два языка на уров�
 - **[SLO Engineering](/The-Way-of-SRE/leaves/engineering/slo-engineering/)** — graceful shutdown, idempotency, retries — кодовая основа того, что измеряется SLO.
 - **[Runbooks](/The-Way-of-SRE/leaves/culture/runbooks/)** — скрипты в runbook (одноразовые fixup-инструменты, диагностические выгрузки) — отдельный класс кода; bash здесь часто выигрывает у Go простотой обновления.
 - **[Incident Response](/The-Way-of-SRE/leaves/practices/incident-response/)** — чтение трейсов, exception stack, pprof в инциденте — главный live-use языка.
+- **[Shell & CLI Craft](/The-Way-of-SRE/leaves/engineering/shell-cli-craft/)** — соседний лист про композицию unix-tools; shell — не «приложение к Go», а отдельный muscle.
+- **[Performance & Profiling](/The-Way-of-SRE/leaves/engineering/performance-profiling/)** — pprof / flame graphs / latency budgets — соседний лист про measure-first дисциплину; работает поверх runtime языка.
+- **[Operating Systems](/The-Way-of-SRE/leaves/engineering/operating-systems/)** — runtime языка живёт поверх OS; GC pauses, scheduler interactions, syscall patterns — intersection.
 
 ## Открытые вопросы
 
-- **Shell & CLI Craft** — отдельный лист про bash / awk / sed / jq / grep идиомы, pipeline-композицию и стиль on-call-скриптов. Сейчас shell сжато упомянут здесь; при углублении ветви — выделить.
-- **CI/CD** — где SRE-код деплоится и проверяется. Сосед под `Programming / Scripting`, отдельный лист.
-- **Performance & Profiling как практика** — pprof / flame graphs / latency budgets — возможно отдельный лист под `Reliability Engineering` или `Observability`, не часть Programming Languages.
+- **Async / Concurrency Patterns по языкам** — структурированное сравнение Go-горутин, Python asyncio, Rust async, Java virtual threads. Возможно отдельный лист под Programming / Scripting.
+- Я не уверен, где правильно проходит граница между «лист про язык» и «лист про runtime / OS interaction». Часть концепций (GC tuning, scheduler interaction) сейчас распределена между этим листом, Performance & Profiling и Operating Systems — overlap намеренный, но возможно нуждается в более чёткой границе.

--- a/src/content/docs/leaves/engineering/resilience-patterns.md
+++ b/src/content/docs/leaves/engineering/resilience-patterns.md
@@ -77,6 +77,7 @@ Resilience — не магия, а **набор явных правил**: circu
 - **[SLI-based Alerting](/The-Way-of-SRE/leaves/engineering/sli-based-alerting/)** — алерты ловят момент активации patterns (circuit open, retry rate up, shed rate ≠ 0).
 - **[Chaos Engineering](/The-Way-of-SRE/leaves/engineering/chaos-engineering/)** — chaos валидирует patterns: circuit breaker реально открывается? retry с backoff не амплифицирует? bulkhead изолирует?
 - **[Progressive Delivery](/The-Way-of-SRE/leaves/practices/progressive-delivery/)** — canary с health gate использует readiness probes и circuit-breaker метрики.
+- **[Operating Systems](/The-Way-of-SRE/leaves/engineering/operating-systems/)** — OS-level health (open file descriptors, conntrack, page cache pressure) — то, на что часто реагирует graceful degradation; resilience pattern triggers — kernel signals.
 
 ## Открытые вопросы
 

--- a/src/content/docs/leaves/engineering/shell-cli-craft.md
+++ b/src/content/docs/leaves/engineering/shell-cli-craft.md
@@ -1,0 +1,95 @@
+---
+title: Shell & CLI Craft
+description: Композиция unix-tools как инструмент SRE — pipelines, awk/sed/jq, дисциплина «когда shell, когда полноценный язык»
+---
+
+:::note[Метаданные листа]
+- **Ветвь:** Engineering
+- **Путь:** Programming / Scripting / Shell & CLI Craft
+- **SFIA-уровни:** 3, 4, 5, 6
+- **Приоритет:** Must Have
+- **Статус:** draft
+:::
+
+«У нас всё на Python / Go, bash — это legacy для боли» — позиция, после которой команда тратит полчаса на трансформацию, которую `awk '{print $2}' | sort | uniq -c | sort -rn` делает за 5 секунд. Shell — это не «костыли», а **инструмент композиции**: 50 лет unix-tools работают как одинаковые входы и выходы, и их можно собрать в нужный конвейер прямо в терминале, без проекта на 200 строк. SRE без shell-беглости в on-call наполовину слеп: пока он пишет Python-script для парсинга логов, инцидент уже погасили те, кто `grep | jq | sort` за минуту. Лист — про беглость в ~30 ключевых tools и про дисциплину «когда shell — правильный выбор, а когда — программа».
+
+Граница: [Programming Languages](/The-Way-of-SRE/leaves/engineering/programming-languages/) — выбор «настоящего» языка для сервисов и инструментов (Go / Python / Rust); shell — для композиции существующих utilities. [CI/CD](/The-Way-of-SRE/leaves/engineering/ci-cd/) — где shell-скрипты живут production-style (pinned, linted, tested). Этот лист — про craftsmanship самого shell.
+
+## Что должен уметь
+
+Главный навык на уровне L4 — знать **где shell кончается, а где начинается язык**. Я регулярно вижу обе крайности: одни пишут 200-строчные bash-monsters с `function`, `getopts`, `trap` (это уже Python с худшим синтаксисом — лучше переписать), другие тянут Python для одностроки `awk '{sum += $1} END {print sum}'` (overkill). Правило, которое работает на практике: если в скрипте появляется три или больше команд `if`, или сложная структура данных, или нетривиальные ошибки, — это уже не shell. Если задача — «прогнать поток через 4 трансформации» — это shell, и любой Python будет проигрывать.
+
+- **L3** — Свободно использует базовый набор: `grep` (с `-r`, `-E`, `-l`, `-c`), `find`, `sort`, `uniq`, `wc`, `head/tail`, `cut`, `tr`, `xargs`. Пишет однострочные pipelines для ad-hoc анализа без выхода в редактор.
+- **L3** — Знает разницу между `'single'` и `"double"` quoting; не цитирует переменные через `$var`, а через `"$var"` (или `"${var}"`); проверяет результат через ShellCheck.
+- **L4** — Бегло пишет `awk` для пост-обработки колоночных данных (одно из самых underused tools в индустрии); читает `sed` без открытия документации для простых замен.
+- **L4** — Использует `jq` для JSON (де-факто стандарт в API-driven debugging); понимает `--arg`, `select()`, `map()`, `to_entries`.
+- **L4** — Пишет on-call shell scripts с минимальной hygiene: `set -euo pipefail`, `trap` для cleanup, явный exit codes, явная error messages в `stderr` (`>&2`).
+- **L5** — Различает interactive shell (короткие команды, alias'ы, history) и scripting shell (defensive style); не путает стиль одного с другим. Pipefail / nounset / errexit — defaults для scripts, не для terminal.
+- **L5** — Знает modern alternatives и осознанно выбирает: `rg` (ripgrep) вместо `grep -r`, `fd` вместо `find`, `bat` вместо `cat` для интерактивного просмотра, `duf` вместо `df`. Понимает, когда modern tool оправдан, а когда POSIX-портабельность важнее.
+- **L5** — Применяет `xargs -P` для параллелизации; `parallel` для более сложных случаев; понимает, когда concurrency в shell ломает мысль и пора уходить в полноценный язык.
+- **L6+** — Выстраивает team-level shell discipline: pinned tool versions в CI / devcontainer, shared profile / aliases, shellcheck в CI, naming convention для on-call scripts.
+- **L6+** — Стратегически: какие задачи в org-shell library (shared bin/, terraform exec scripts, monitoring-pull scripts) — а какие настало время мигрировать в полноценный сервис.
+
+## Материалы
+
+### Книги
+
+- Brian Kernighan, Rob Pike — **[The Unix Programming Environment](https://en.wikipedia.org/wiki/The_Unix_Programming_Environment)** (Prentice Hall, 1984). 40 лет, и не устарела. Глава 4 «Filters» — лучший introduction в композицию unix-tools. Если выбирать одну книгу — эту.
+- Eric S. Raymond — **[The Art of Unix Programming](http://www.catb.org/~esr/writings/taop/html/)** (Addison-Wesley, 2003). Не tutorial по shell, а философия: «write programs that do one thing well», «text streams are universal interface». Полезно для понимания, почему shell-tooling выживает 50 лет.
+- Cameron Newham — **[Learning the bash Shell](https://www.oreilly.com/library/view/learning-the-bash/0596009658/)** (O'Reilly, 3-е изд., 2005). Канонический справочник по bash specifically. Не для линейного чтения, а для lookup.
+- Dave Taylor, Brandon Perry — **[Wicked Cool Shell Scripts](https://nostarch.com/wcss2)** (No Starch Press, 2-е изд., 2017). Сборник реальных scripts с разбором; полезен как идиоматический pattern reference.
+
+### Статьи и доклады
+
+- **[Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html)**. Если выбирать одну shell style guide — эту. Прагматичная, не «теоретическая». Все рекомендации обоснованы. По моим наблюдениям, чаще всего org-level shell standards вырастают из неё.
+- **[ShellCheck Wiki](https://www.shellcheck.net/wiki/)**. Не статья, а коллекция объяснений common shell-ошибок. Каждое предупреждение ShellCheck — отдельная страница с подробным объяснением. Лучший способ учиться bash — читать wiki после первого фейла своего скрипта.
+- Robert Mecklenburg — **[Managing Projects with GNU Make](https://www.oreilly.com/library/view/managing-projects-with/0596006101/)** (O'Reilly, 3-е изд., 2004). Make — не shell, но используется вместе. Глава про автоматизацию workflow в команде через Makefile — практическая.
+- **[The Art of Command Line](https://github.com/jlevy/the-art-of-command-line)**. Curated cheat sheet на GitHub (~50k stars). Хорошая точка proof-of-knowledge: если 60% содержимого вам не знакомо — есть, что доучить.
+
+### Инструменты
+
+- **bash** — POSIX-совместимый default. Если выбирать один shell для скриптов — bash. Zsh лучше для интерактивной работы, но в scripts лучше bash для portability.
+- **[ShellCheck](https://www.shellcheck.net/)** — линтер для shell. Обязательный pre-commit / CI hook для любого репозитория с .sh файлами. Ловит подавляющее большинство bash gotchas.
+- **[jq](https://jqlang.github.io/jq/)** — де-факто стандарт для JSON в shell. По моим наблюдениям, навык jq на уровне `select() | map()` отличает рядового SRE от senior'а в on-call ситуациях с REST API.
+- **[yq](https://github.com/mikefarah/yq)** — то же для YAML; критично для kubernetes-команд (помогает читать manifests, helm-values).
+- **[ripgrep (rg)](https://github.com/BurntSushi/ripgrep)** / **[fd](https://github.com/sharkdp/fd)** / **[bat](https://github.com/sharkdp/bat)** / **[delta](https://github.com/dandavison/delta)** — modern замены `grep -r` / `find` / `cat` / git diff viewer. По моим наблюдениям, чаще выбирают именно эту четвёрку для personal setup.
+- **[GNU parallel](https://www.gnu.org/software/parallel/)** / **xargs -P** — параллелизация. `parallel` мощнее, но learning curve выше; `xargs -P` хватает в 80% случаев.
+- **[Modern Unix](https://github.com/ibraheemdev/modern-unix)** — curated list современных альтернатив classic unix-tools. Полезно для periodic refresh personal toolchain.
+- **Анти-инструмент:** «300-строчный bash-script с function / case / getopts». Это уже не shell — лучше переписать в Python / Go.
+
+## Best practices
+
+Главный публичный кейс — не отдельный инцидент, а феномен **`jq` и `kubectl`**: jq за ~10 лет превратился из niche-tool в обязательный навык для любого, кто работает с REST API; `kubectl ... -o json | jq` — самая частая идиома в kubernetes-on-call. Это пример того, как **композиция простых tools** доминирует над «built-in complex tools»: вместо того чтобы добавлять в kubectl полноценный query-language, индустрия сошлась на «kubectl output JSON → jq делает остальное». Я регулярно вижу команды, в которых senior'ы за минуту получают answer на сложный k8s-вопрос через `kubectl get ... -o json | jq '...'`, а junior'ы за полчаса пишут Python с k8s client library под тот же вопрос. Это не критика junior'ов — это пример того, насколько мощна «cheap composition» через shell, когда инженер беглый.
+
+**Короткие правила:**
+
+- **`set -euo pipefail` — defaults для каждого scripted файла.** Без `errexit` ошибка в середине ломает invariants; без `nounset` typo в имени переменной превращается в `""`; без `pipefail` failure в начале pipeline теряется. Не нравится — пиши защиту явно, но не молча игнорируй.
+- **Quote variables: `"$var"`, не `$var`.** Без кавычек слова со spaces / glob characters ломают код. ShellCheck ловит это автоматически — не игнорируй.
+- **Three-`if` правило: если в скрипте появляется три или больше условных ветвей или нетривиальная структура — это уже не shell.** Перепиши в Python / Go. Долгие bash-monsters — это тех-долг, который рос годами; здоровая команда вовремя останавливается.
+
+Подробнее:
+
+**`awk` — самый underused tool в индустрии.** Огромная часть SRE-задач — это «возьми колоночный output, посчитай сумму / уникальные / отсортируй по N-й колонке». В Python это 10 строк, в `awk '{sum[$1] += $2} END {for (k in sum) print k, sum[k]}'` — одна строка прямо в pipe. По моим наблюдениям, разница между беглым и не-беглым в shell — почти всегда `awk`-fluency. Это не «выучить awk целиком» (язык богатый, легко утонуть) — это знать ~10 идиом наизусть. Один день, заметная разница на годы.
+
+**Interactive vs scripted shell — разный стиль.** Распространённая ошибка — писать scripts стилем terminal-сессии (без quoting, без error handling, без `set -e`) или, наоборот, в terminal писать defensive ad-hoc команды (теряется скорость). В terminal: короткие, можно ошибиться, history спасёт. В scripts: pipefail / nounset, явный error handling, ShellCheck'нуто. Я регулярно вижу команды, в которых эта разница не сформулирована — и script-quality плавающая.
+
+**On-call shell-library заменяет «волшебные знания в голове».** В zрелой SRE-команде в shared repo лежит ~20–40 скриптов: «дать список pods в bad state по cluster», «exec в случайный pod по label», «достать last 50 stack traces из service logs». Это **assets команды**, не личный setup. По моим наблюдениям, разница между новичком и senior'ом в той же команде сокращается на месяцы, если такая library существует и поддерживается. Без неё каждый новый человек заново изобретает свои pipelines.
+
+**Pin tool versions для production scripts.** Bash-script, использующий `awk`, работает на BSD `awk` иначе, чем на GNU `awk`. То же с `sed`, `grep -P`, `date` (BSD vs GNU). Production scripts в CI пинуют tooling через container image / asdf / nix; не пинуют — получают «работало на моём ноуте, ломается в CI». Это не bash gotcha — это discipline of supply chain для shell scripts.
+
+## Связанные листья
+
+- **[Programming Languages](/The-Way-of-SRE/leaves/engineering/programming-languages/)** — выбор настоящего языка для сервисов / tools (Go / Python / Rust); shell — для композиции и ad-hoc. Граница: три if'а — переходи в язык.
+- **[CI/CD](/The-Way-of-SRE/leaves/engineering/ci-cd/)** — shell-scripts в pipeline должны быть pinned, linted (ShellCheck), tested. CI — где scripted-style critical.
+- **[Operating Systems](/The-Way-of-SRE/leaves/engineering/operating-systems/)** — shell — главный интерфейс к OS; знание `/proc`, `/sys`, syscall tracing (strace) — overlap с OS knowledge.
+- **[Networking](/The-Way-of-SRE/leaves/engineering/networking/)** — `tcpdump`, `ss`, `dig`, `curl -v`, `mtr` — все сетевые tools — это shell-композиция; shell-беглость — пре-условие для networking-беглости.
+- **[Runbooks](/The-Way-of-SRE/leaves/culture/runbooks/)** — runbook шаги часто включают shell-команды; их качество (правильно ли quoted, есть ли error handling) определяет real-incident usability.
+- **[Performance & Profiling](/The-Way-of-SRE/leaves/engineering/performance-profiling/)** — `perf`, `strace`, `ltrace`, `bpftrace` — CLI-инструменты; profiling-беглость требует shell-беглости.
+- **[Toil Tracking](/The-Way-of-SRE/leaves/engineering/toil-tracking/)** — recurring shell-команды — кандидат на shared script в team library; tracking ловит signal «эту pipeline-команду набирали 20 раз — пора в bin/».
+
+## Открытые вопросы
+
+- **Zsh vs Bash для команды** — для personal terminal zsh обычно выигрывает; для shared scripts — bash для portability. Но граница «где terminal становится скриптом» нечёткая.
+- **Modern shell альтернативы** *(TBD)* — fish / nushell / oil. Стоит ли в SRE-команде переходить — открытый вопрос, общепринятой позиции нет.
+- **CLI design для собственных tools** — отдельная подтема (когда команда пишет свой CLI: Cobra / Click / argparse, exit codes, output format). Возможно отдельный лист на стыке Programming Languages.
+- Я не уверен, как **тестировать shell-scripts** правильно. Bats / shunit2 существуют, но adoption низкий; на практике большинство bash-scripts не имеют tests. Если у вас есть рабочая practice — расскажите через PR.

--- a/src/content/docs/leaves/engineering/test-strategy.md
+++ b/src/content/docs/leaves/engineering/test-strategy.md
@@ -90,11 +90,11 @@ description: Дисциплина проектирования testing portfolio
 - **[SLO Engineering](/The-Way-of-SRE/leaves/engineering/slo-engineering/)** — performance / load tests генерируют baselines для SLI / SLO. Без load testing SLO targets — guess.
 - **[Toil Tracking](/The-Way-of-SRE/leaves/engineering/toil-tracking/)** — manual test execution = toil; automation тестов — toil reduction.
 - **[Vulnerability Management](/The-Way-of-SRE/leaves/practices/vulnerability-management/)** — security testing (SAST / DAST / fuzzing) — отдельная категория в test portfolio.
+- **[Performance & Profiling](/The-Way-of-SRE/leaves/engineering/performance-profiling/)** — load / performance testing — runtime-side проверки; profile-driven optimization — продолжение измерения после first deploy. Соседние листы.
 
 ## Открытые вопросы
 
 - **Build Reproducibility / Hermetic Builds** *(TBD)* — Bazel-style hermetic compilation, deterministic builds. Может стать отдельным листом под Programming / Scripting либо подсекцией Supply Chain Security.
-- **Performance & Profiling как отдельный лист** *(TBD)* — pprof / perf / async-profiler / flame graphs. Tightly связан с этим листом, но достоин отдельной глубины.
 - **Fuzzing как отдельная подобласть** *(TBD)* — libFuzzer / AFL / jazzer / OSS-Fuzz / Go native fuzz. Security-flavoured, но техника — property-based testing с генеративным input space.
 - **TDD как practice vs principle** *(TBD)* — граница к этому листу: TDD = workflow (red-green-refactor); Test Strategy = portfolio architecture.
 - **Shadow Traffic / Traffic Replay testing** *(TBD)* — запись prod traffic и replay против new version в staging. Polyglot между chaos / load / regression / contract.

--- a/src/content/docs/sre-engineering.mdx
+++ b/src/content/docs/sre-engineering.mdx
@@ -49,7 +49,7 @@ import BranchView from '../../components/BranchView.astro';
 
 Разработка инструментов для автоматизации, операционных сервисов, систем контроля надёжности и снижения toil. SRE пишет код — это принципиальное отличие от классических ops.
 
-**L2-концепты:** Programming Languages · Shell & CLI Craft · CI/CD
+**L2-концепты:** Programming Languages · Shell & CLI Craft · CI/CD · Test Strategy · Performance & Profiling
 
 ### Database Reliability
 
@@ -65,4 +65,4 @@ import BranchView from '../../components/BranchView.astro';
 
 ---
 
-Бюджет узлов: 1 корень + 8 L1 + 33 L2 = **42 узла** (в пределах политики `≤ 80` на проект).
+Бюджет узлов: 1 корень + 8 L1 + 35 L2 = **44 узла** (в пределах политики `≤ 80` на проект).

--- a/src/data/roadmap.ts
+++ b/src/data/roadmap.ts
@@ -215,6 +215,11 @@ export const roadmap: Roadmap = {
               label: 'Networking',
               href: '/leaves/engineering/networking/',
             },
+            {
+              id: 'operating-systems',
+              label: 'Operating Systems',
+              href: '/leaves/engineering/operating-systems/',
+            },
           ],
         },
         {
@@ -228,6 +233,11 @@ export const roadmap: Roadmap = {
               href: '/leaves/engineering/programming-languages/',
             },
             {
+              id: 'shell-cli-craft',
+              label: 'Shell & CLI Craft',
+              href: '/leaves/engineering/shell-cli-craft/',
+            },
+            {
               id: 'ci-cd',
               label: 'CI/CD',
               href: '/leaves/engineering/ci-cd/',
@@ -236,6 +246,11 @@ export const roadmap: Roadmap = {
               id: 'test-strategy',
               label: 'Test Strategy',
               href: '/leaves/engineering/test-strategy/',
+            },
+            {
+              id: 'performance-profiling',
+              label: 'Performance & Profiling',
+              href: '/leaves/engineering/performance-profiling/',
             },
           ],
         },


### PR DESCRIPTION
## Summary

Третья батч из изначального плана новых листьев. Engineering depth pack: три листа, формирующие coherent инженерный фундамент (shell craftsmanship + measurement discipline + OS internals). После этого PR в изначальном плане остаётся **1 лист** — Composite SLO Methodology.

**Новые листья (все Engineering):**

- **engineering/shell-cli-craft** — композиция unix-tools как инструмент SRE. Pipelines, awk/sed/jq, дисциплина «когда shell, когда полноценный язык». Three-if rule, on-call shell library, ShellCheck в CI. Публичный кейс: \`kubectl ... -o json | jq\` как идиома индустрии — пример \"cheap composition\" доминирующей над «built-in complex tools».
- **engineering/performance-profiling** — measure-first дисциплина: pprof / perf / flame graphs / USE method, continuous profiling, differential profiling. Latency budget per component. Публичный кейс: Brendan Gregg's CPU flame graph work at Netflix (\"Java in Flames\" 2015) — 8x speedup от одной regex-fix, найденной за 30 секунд через flame graph.
- **engineering/operating-systems** — OS как слой между процессом и железом: namespaces / cgroups / syscalls / page cache / network stack / eBPF. \`/proc\` как source of truth, container ≠ VM, OOM-killer mechanics. Публичный кейс: Brendan Gregg's «60 second Linux performance analysis» как established canon.

**Размещение по L1:**

- Programming / Scripting / Shell & CLI Craft (matches existing L2)
- Programming / Scripting / **Performance & Profiling** (NEW L2)
- IT Infrastructure / Operating Systems (matches existing L2)

**Cross-ссылки в смежных листьях** — заменены TBD-маркеры на реальные ссылки:
- \`programming-languages\` → \`shell-cli-craft\`, \`performance-profiling\`, \`operating-systems\`
- \`networking\` → \`operating-systems\` (kernel networking, TCP-стек, namespaces — overlap)
- \`test-strategy\` → \`performance-profiling\` (load testing + profile-driven optimization — соседние)
- \`resilience-patterns\` → \`operating-systems\` (OS-level health triggers)
- \`capacity-planning\` → \`performance-profiling\` (resource efficiency)

**Обновлено:**
- \`astro.config.mjs\` sidebar — 3 новых пункта (Operating Systems после Networking, Shell после Programming Languages, Performance & Profiling в конце)
- \`src/data/roadmap.ts\` — 3 новых leaf-узла в существующих L1
- \`sre-engineering.mdx\` — L2-список Programming/Scripting +Test Strategy +Performance & Profiling, бюджет узлов 42→44
- \`README.md\` — Engineering 16→19 (всего: 41→44 листа)

## Test plan

- [x] \`npx astro build\` — clean, 54 страницы без ошибок
- [x] 3 новых leaf-страницы строятся: \`/leaves/engineering/shell-cli-craft/\`, \`/leaves/engineering/performance-profiling/\`, \`/leaves/engineering/operating-systems/\`
- [ ] Визуально проверить, что 3 листа в Engineering sidebar расположены в логичных местах
- [ ] Проверить отсутствие битых внутренних ссылок (TBD → реальные)
- [ ] \`BranchView\` корректно рендерит Programming / Scripting с 5 листами (Programming Languages, Shell & CLI Craft, CI/CD, Test Strategy, Performance & Profiling)