### PR TITLE
feat(leaves): Composite SLO Methodology — изначальный план закрыт (10/10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ graph LR
 ```
 
 - **[SRE Culture](https://jtprogru.github.io/The-Way-of-SRE/sre-culture/)** — нормы, отношения, обмен опытом. Главный объект — люди и нормы. **8 листьев** на полной глубине.
-- **[SRE Engineering](https://jtprogru.github.io/The-Way-of-SRE/sre-engineering/)** — технические компетенции и стек. Главный объект — системы. **19 листьев** на полной глубине.
+- **[SRE Engineering](https://jtprogru.github.io/The-Way-of-SRE/sre-engineering/)** — технические компетенции и стек. Главный объект — системы. **20 листьев** на полной глубине.
 - **[SRE Practices](https://jtprogru.github.io/The-Way-of-SRE/sre-practices/)** — операционные процессы и ритуалы. Главный объект — процесс. **17 листьев** на полной глубине.
 
 Принцип разделения ветвей, политика контроля детализации, оси priority и SFIA — в [Методологии](https://jtprogru.github.io/The-Way-of-SRE/methodology/).

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -81,6 +81,7 @@ export default defineConfig({
                 { label: 'Symptom vs Cause Alerting', link: '/leaves/engineering/symptom-vs-cause-alerting/' },
                 { label: 'Alert Fatigue Management', link: '/leaves/engineering/alert-fatigue-management/' },
                 { label: 'SLO Engineering', link: '/leaves/engineering/slo-engineering/' },
+                { label: 'Composite SLO Methodology', link: '/leaves/engineering/composite-slo-methodology/' },
                 { label: 'Capacity Planning', link: '/leaves/engineering/capacity-planning/' },
                 { label: 'Resilience Patterns', link: '/leaves/engineering/resilience-patterns/' },
                 { label: 'Chaos Engineering', link: '/leaves/engineering/chaos-engineering/' },

--- a/src/content/docs/leaves/engineering/composite-slo-methodology.md
+++ b/src/content/docs/leaves/engineering/composite-slo-methodology.md
@@ -1,0 +1,95 @@
+---
+title: Composite SLO Methodology
+description: Математика multi-component SLO — серийные / параллельные пути, vendor SLA как input, critical path, не «99.95% потому что хочется четыре девятки»
+---
+
+:::note[Метаданные листа]
+- **Ветвь:** Engineering
+- **Путь:** Reliability Engineering / Composite SLO Methodology
+- **SFIA-уровни:** 4, 5, 6
+- **Приоритет:** Mandatory
+- **Статус:** draft
+:::
+
+«Наш SLO — 99.95%» — типичная декларация после quarterly planning. Если посмотреть на сервис-граф: 4 зависимости с vendor SLA 99.9% ([auth](/The-Way-of-SRE/glossary/#auth), payment, CDN, managed DB), 2 internal-сервиса с 99.99%, shared DNS / TLS layer. Простая арифметика для последовательного пути: `0.999⁴ × 0.9999² × 0.9999 ≈ 0.9956` — наш достижимый SLO ceiling **99.56%**, не 99.95%. Composite SLO Methodology — это **математика multi-component систем**: когда «хочется четыре девятки» сталкивается с реальностью composite, и нужно либо снизить commitment, либо добавить redundancy, либо явно принять honest baseline. Я регулярно вижу команды, которые декларируют SLO без composite math — и потом первый dependency outage сжигает квартальный error budget целиком.
+
+Граница: [SLO Engineering](/The-Way-of-SRE/leaves/engineering/slo-engineering/) — *как формулировать* SLO для одного компонента (SLI, target, window); этот лист — *как складывать* SLO для multi-component system. [Vendor Management](/The-Way-of-SRE/leaves/practices/vendor-management/) — vendor SLA как input в composite math; reliability-side зависимостей от внешних сервисов. [Resilience Patterns](/The-Way-of-SRE/leaves/engineering/resilience-patterns/) — что делать, чтобы composite SLO **превысить** математический ceiling через redundancy / graceful degradation.
+
+## Что должен уметь
+
+Главный навык на уровне L5 — отличать **serial** от **parallel** dependencies и применять правильную формулу. Я регулярно вижу команды, которые перемножают SLA всех зависимостей подряд — но если CDN имеет fallback на origin, это **parallel** (отказ только при двойном отказе), и формула совсем другая: `1 − (1 − SLA_cdn)(1 − SLA_origin)`. Различить serial vs parallel — это не «формальность», это разница между 99.5% и 99.99% при том же наборе компонентов. Если граф нарисован, формула механическая; если граф «в голове» — composite math всегда оптимистичнее реальности.
+
+- **L4** — Понимает базовую арифметику: для serial dependencies own SLO ≤ product(deps SLAs); знает, что vendor SLA — нижняя граница (worst case), а не expectation.
+- **L4** — Идентифицирует **critical path** через service graph своего сервиса: какие dependencies в request-path каждого user-facing endpoint.
+- **L4** — Считает composite math для своего user journey: serial path × required-uptime parallel components × shared infrastructure.
+- **L5** — Различает serial vs parallel dependencies и применяет правильные формулы. Parallel: `1 − ∏(1 − SLA_i)`, serial: `∏ SLA_i`.
+- **L5** — Включает **vendor SLAs как нижнюю границу** в composite math, не как ожидаемый uptime. SLA — contractual floor (vendor готов вернуть credit); real uptime может быть выше, но planning под SLA, не под наблюдаемое.
+- **L5** — Разделяет **mandatory vs best-effort dependencies**: observability backplane / logging pipeline / async analytics — не часть user-facing composite (их падение не означает «user страдает»); auth / payment / DB — часть.
+- **L5** — Применяет multi-burn-rate alerting **per critical path / per journey**, не только per service. SLI собирается на journey-уровне (synthetic / RUM / business event), не только на endpoint.
+- **L6+** — Org-level composite portfolio: какие user journeys получают SLO commitment, какие остаются best-effort. Не каждый journey стоит SLO — обоснование выбора явное.
+- **L6+** — Composite math как **input для capacity и cost decisions**: где redundancy оправдана (revenue-critical journey), где нет (low-traffic admin tool). Связь с [Cost Management](/The-Way-of-SRE/leaves/engineering/cost-management/) явная.
+- **L6+** — Refresh composite math после каждой major dependency change (new vendor, removed redundancy, schema change затрагивающий fan-out). Без refresh composite SLO становится stale за квартал.
+
+## Материалы
+
+### Книги
+
+- Alex Hidalgo — **[Implementing Service Level Objectives](https://www.alex-hidalgo.com/the-slo-book)** (O'Reilly, 2020). Глава 11 «Service Level Objectives and Probability» — единственная книжная глава, посвящённая composite math явно. Если выбирать одну ссылку — эту.
+- Betsy Beyer et al. (eds) — **[The Site Reliability Workbook](https://sre.google/workbook/implementing-slos/)** (O'Reilly, 2018), глава 2 «Implementing SLOs». Раздел про dependencies upstream / downstream — Google's подход. Не как глубоко как Hidalgo, но canonical.
+- Betsy Beyer et al. (eds) — **[Site Reliability Engineering](https://sre.google/sre-book/embracing-risk/)** (O'Reilly, 2016), глава 3 «Embracing Risk». Не composite напрямую, но фундамент для понимания, что «target uptime — это decision с trade-offs», не aspirational число.
+
+### Статьи и доклады
+
+- Marc Brooker — **[Combining SLAs](https://brooker.co.za/blog/2022/05/13/sla.html)** (личный блог, 2022). Marc Brooker (AWS Principal Engineer) пишет про combined SLA arithmetic для distributed systems. Самый сжатый практический resource по теме.
+- Stephen Thorne — **[Composite SLOs aren't as scary as they seem](https://blog.alexewerlof.com/p/composite-slo)** / **[Composite SLOs in practice](https://medium.com/@alexewerlof/composite-slo-bd84a9697f6c)** (Medium, 2020+). Несколько блог-постов по теме с конкретными формулами и diagrams. Полезно как practical complement к Hidalgo's главе.
+- Charity Majors — **[SLO Math](https://charity.wtf/2022/01/05/slos-math-fundamentals/)** (личный блог, 2022). Критический взгляд на «multiply everything» подход; обоснование, почему journey-level SLI лучше, чем component-level composite.
+- Google Cloud — **[SLI and SLO best practices](https://cloud.google.com/blog/products/devops-sre/sre-fundamentals-slis-slas-and-slos)**. Не глубоко по composite, но canonical reference для vocabulary.
+
+### Инструменты
+
+- **[OpenSLO](https://openslo.com/)** — vendor-agnostic YAML spec для SLO; поддерживает composite через `objectives[]` с многими SLI. Используется в Sloth / Pyrra / Nobl9.
+- **[Sloth](https://sloth.dev/)** — SLO-as-code для Prometheus; multi-window multi-burn-rate alert rules генерируются автоматически. Composite SLO собирается через несколько SLO definitions + custom recording rules.
+- **[Pyrra](https://github.com/pyrra-dev/pyrra)** — alternative к Sloth, более opinionated. По моим наблюдениям, чаще выбирают Sloth для existing setups, Pyrra — для greenfield.
+- **[Nobl9](https://www.nobl9.com/)** — коммерческая SLO platform, лучшая native поддержка composite SLO в индустрии. Если SLO program critical и есть бюджет — рассматривать.
+- **[error-budget-policy](https://github.com/google/error-budget-policy)** — open-source шаблон error budget policy с composite-considerations.
+- **Анти-инструмент:** «composite SLO в Excel-sheet, обновляемый раз в квартал вручную». Это не tool, это invitation к stale math. Composite живёт в коде (OpenSLO YAML / Sloth definitions) — обновляется PR'ом при изменении dependency graph.
+
+## Best practices
+
+Главный публичный кейс — не отдельный инцидент, а **широко документированная статистика AWS SLA**. AWS публикует SLA на каждый сервис (S3 — 99.9% для standard storage, EC2 — 99.99% для regional fleet, RDS — 99.95% для Multi-AZ). Если построить типовое веб-приложение в AWS — Application Load Balancer (99.99%) → EC2 fleet (99.99%) → RDS Multi-AZ (99.95%) → S3 (99.9%) для статики, всё в одном регионе — composite serial SLA: `0.9999 × 0.9999 × 0.9995 × 0.999 ≈ 0.9983`. Это **99.83%** — ceiling, который AWS contractually готов компенсировать через credits. Многие команды декларируют 99.95% или выше, не глядя на эту арифметику. Я регулярно вижу архитектурные обсуждения «как нам достичь 99.99% uptime», в которых composite math никогда не появляется — и достижение 99.99% становится либо реалистическим (если добавлены multi-region failover, multi-AZ, redundancy), либо wishful (если просто декларация поверх той же топологии). Один лист бумаги с composite math перед SLO-commitment — час работы и год честности.
+
+**Короткие правила:**
+
+- **Critical path сначала, math потом.** Без идентифицированного critical path через сервис-граф composite math — это произвольная сумма SLA. Нарисовать граф, отметить «без чего user страдает» — пре-условие.
+- **Vendor SLA — floor, не ceiling.** Vendor SLA — то, что vendor готов compensate (credits) при нарушении. Не «реальный uptime»; не «ожидание». Composite math на SLA — conservative baseline; реальность обычно лучше, но planning под worst case.
+- **Mandatory vs best-effort dependencies явно.** Observability backplane / logging / async analytics — best-effort (их down ≠ user страдает); auth / payment / DB / CDN — mandatory. Включать в composite только mandatory; иначе SLO ceiling drops без user-facing reason.
+
+Подробнее:
+
+**Serial vs parallel — главное место ошибок.** Распространённая ошибка: считать все dependencies в одну формулу `∏ SLA_i`. Реально: если CDN имеет fallback на origin, это **parallel** — отказ только при двойном отказе, формула `1 − (1 − SLA_cdn)(1 − SLA_origin) ≈ 1 − 0.001 × 0.0001 = 99.99999%`. Если auth имеет primary + secondary identity provider — то же. Если DB Multi-AZ — это уже parallel внутри одного «AZ-level» SLA, и vendor SLA включает Multi-AZ в свой 99.95%. По моим наблюдениям, серьёзная composite math для типовой команды занимает 1–2 дня (рисование графа + classification + формулы); результат — picture, который меняет SLO-committee discussions.
+
+**Composite SLO — это не «потолок 99.X%», это семейство SLO per user journey.** Сервис обычно обслуживает несколько user journeys (login, purchase, browse, support). У каждого journey свой critical path и свой composite math. Login может иметь 99.95% (мало dependencies), purchase — 99.5% (payment processor добавляет 99.9% × ...), browse — 99.9%. Команда не commit'ит **один** SLO на сервис — она commit'ит per journey. Я регулярно вижу команды, у которых один service-level SLO, и в день любого incident команда не может понять «какая часть продукта затронута».
+
+**Vendor SLA включается с conservatism, не optimism.** Vendor может иметь observed uptime 99.99%, но SLA — 99.9%. Использовать SLA как input в composite, не observed. **Why:** vendor может изменить infrastructure, лоадить других customers, иметь региональный incident — observed uptime прошлого квартала не предсказывает следующий. SLA — это нижняя граница, которую vendor готов защищать contractually. Conservatism на vendor side освобождает internal budget на собственные инциденты.
+
+**Refresh composite math после каждой major dependency change.** Service graph меняется: новый vendor (Stripe → Adyen migration), removed redundancy (closed second region for cost), added intermediate cache (Redis layer перед DB). После каждой такой change composite math должна быть пересчитана и SLO commitment пересмотрен. Я регулярно вижу команды, у которых composite SLO документ датирован 18 месяцев назад, а сервис-граф за это время изменился 3 раза — math не отражает реальности.
+
+**Multi-burn-rate per journey, не per component.** Classical multi-burn-rate alerting часто строится per individual SLI (latency, error rate каждого endpoint). Composite world требует journey-level SLI: synthetic user journey, RUM event chain, business transaction (order placed). Алерт срабатывает при burn на journey-уровне — то есть «пользователи реально не могут купить», а не «один из 12 backend endpoints деградировал». По моим наблюдениям, разница между mature SLO program и developing — наличие journey-level SLI как primary, component-level — как diagnostic.
+
+## Связанные листья
+
+- **[SLO Engineering](/The-Way-of-SRE/leaves/engineering/slo-engineering/)** — *как формулировать* SLO для одного компонента; этот лист — *как складывать* SLO для multi-component system. Читать вместе.
+- **[Vendor Management](/The-Way-of-SRE/leaves/practices/vendor-management/)** — vendor SLAs — input в composite math. Vendor management ведёт inventory, composite methodology — использует.
+- **[Resilience Patterns](/The-Way-of-SRE/leaves/engineering/resilience-patterns/)** — что делать, чтобы composite SLO **превысить** математический ceiling: redundancy, graceful degradation, fallbacks. Resilience patterns превращают serial dependencies в parallel.
+- **[Capacity Planning](/The-Way-of-SRE/leaves/engineering/capacity-planning/)** — composite SLO определяет, какие компоненты требуют redundancy (parallel paths), а это — capacity decisions с лead time.
+- **[Cost Management](/The-Way-of-SRE/leaves/engineering/cost-management/)** — redundancy для composite SLO improvement имеет cost; trade-off «one more nine» vs cost доллар-on-доллар.
+- **[SLI-based Alerting](/The-Way-of-SRE/leaves/engineering/sli-based-alerting/)** / **[Symptom vs Cause Alerting](/The-Way-of-SRE/leaves/engineering/symptom-vs-cause-alerting/)** — journey-level SLI требует multi-burn-rate alerting на composite path, не только per component.
+- **[SLO / Budget Review](/The-Way-of-SRE/leaves/culture/slo-budget-review/)** — ритуал, на котором composite math пересматривается: что изменилось в graph, осталась ли арифметика честной, нужно ли скорректировать commitment.
+
+## Открытые вопросы
+
+- **Composite SLO для async / batch systems** *(TBD)* — formulae для freshness / lag-based SLI в composite. Классическая теория покрывает online; batch (Airflow / Dagster pipelines, Kafka streams) — отдельная подобласть с собственными формулами.
+- **Probabilistic composite vs worst-case** — current approach — multiply / sum (worst case); probabilistic подход (Monte Carlo с distribution per dependency) точнее, но adoption низкий. Если у вас есть practice — расскажите через PR.
+- **SLO Decomposition** — обратная задача: «нам нужен 99.95% user-facing, какой SLO budget per component». Не аддитивна, требует optimization.
+- **Composite SLO ↔ Error Budget Policy integration** — как несколько journey-level error budgets взаимодействуют (один journey burning не должен блокировать deploys другого).
+- Я не уверен, как **корректно учитывать correlated failures** в composite (один cloud region down → все zones в regio'не impact'нуты, math не аддитивна). Hidalgo упоминает, но не даёт canonical answer. Если есть practical model — расскажите через PR.

--- a/src/content/docs/leaves/engineering/slo-engineering.md
+++ b/src/content/docs/leaves/engineering/slo-engineering.md
@@ -74,9 +74,8 @@ description: Инженерная сторона SLO — определение 
 - **[Capacity Planning](/The-Way-of-SRE/leaves/engineering/capacity-planning/)** — capacity planning опирается на SLO как на reliability-таргет.
 - **[Vendor Management](/The-Way-of-SRE/leaves/practices/vendor-management/)** — vendor SLAs — нижняя граница composite SLO math: own SLO ≤ product(vendor SLAs × own reliability) без явной redundancy.
 - **[Symptom vs Cause Alerting](/The-Way-of-SRE/leaves/engineering/symptom-vs-cause-alerting/)** — symptom-side SLI — то, на что алертит paging-level; cause-side — diagnostic context.
+- **[Composite SLO Methodology](/The-Way-of-SRE/leaves/engineering/composite-slo-methodology/)** — *как формулировать* SLO для одного компонента (этот лист) и *как складывать* SLO для multi-component системы. Читать вместе.
 
 ## Открытые вопросы
-
-- **Composite SLO methodology** — нет канонической формулы для составления SLO из компонентов; реальные команды решают через симуляцию или эмпирику. Возможно, отдельный лист.
 - **Real-time vs synthetic SLI** — когда какие, в какой комбинации, как избежать gap'ов.
 - Я регулярно вижу sloppy формулировки SLI в командах после первой настройки («≥ 99% requests success»). Без conkretики «что такое request», «что такое success», «что такое window» это не SLI, это слоган. Хороший SLI читается как `count(http_requests{status!~"5.."} | window_5m) / count(http_requests{is_synthetic="false"} | window_5m) > 0.999`. Если в команде нет такой строгости — стоит обсудить, как её внедрить.

--- a/src/content/docs/leaves/practices/vendor-management.md
+++ b/src/content/docs/leaves/practices/vendor-management.md
@@ -84,6 +84,7 @@ description: Engineering-практика управления зависимо�
 - **[Incident Response](/The-Way-of-SRE/leaves/practices/incident-response/)** — vendor incident — отдельный класс incident; IC immediately checks vendor status в первые 5 минут.
 - **[Resilience Patterns](/The-Way-of-SRE/leaves/engineering/resilience-patterns/)** — graceful degradation для vendor unavailability: cached responses, fallback providers, degraded mode.
 - **[Architecture Decision Records](/The-Way-of-SRE/leaves/practices/architecture-decision-records/)** — vendor selection — типичный ADR; концентрация vs diversification — recurring decision.
+- **[Composite SLO Methodology](/The-Way-of-SRE/leaves/engineering/composite-slo-methodology/)** — vendor SLAs — input в composite math; этот лист ведёт inventory, composite methodology — использует.
 
 ## Открытые вопросы
 
@@ -91,5 +92,4 @@ description: Engineering-практика управления зависимо�
 - **Vendor Concentration Metrics** *(TBD)* — как количественно мерить vendor concentration risk (% of revenue / % of critical paths / blast radius).
 - **Open-source Dependencies как «vendor»** — semi-vendor relationships (Linux distro, k8s, PostgreSQL, etc); похожие governance вопросы, разный контекст.
 - **Vendor Negotiation Tactics** — engineering-сторона переговоров (technical evidence для лучших terms); пересечение с procurement role.
-- **Composite SLO Methodology** *(TBD)* — формальный math для multi-vendor multi-dependency SLO; отдельный лист.
 - Я не уверен, какая **минимальная granularity** vendor inventory правильна (на уровне vendor / на уровне отдельных endpoints / на уровне feature). Если у вас есть рабочая модель — расскажите через PR.

--- a/src/content/docs/sre-engineering.mdx
+++ b/src/content/docs/sre-engineering.mdx
@@ -25,7 +25,7 @@ import BranchView from '../../components/BranchView.astro';
 
 Определение и управление SLO/SLA, error budget policy, capacity planning и проектирование систем с учётом надёжности. Включает chaos engineering и fault injection для проверки устойчивости.
 
-**L2-концепты:** SLO Engineering · Chaos Engineering · Capacity Planning · Disaster Recovery · Resilience Patterns
+**L2-концепты:** SLO Engineering · Composite SLO Methodology · Chaos Engineering · Capacity Planning · Disaster Recovery · Resilience Patterns
 
 ### Toil Reduction
 
@@ -65,4 +65,4 @@ import BranchView from '../../components/BranchView.astro';
 
 ---
 
-Бюджет узлов: 1 корень + 8 L1 + 35 L2 = **44 узла** (в пределах политики `≤ 80` на проект).
+Бюджет узлов: 1 корень + 8 L1 + 36 L2 = **45 узлов** (в пределах политики `≤ 80` на проект).

--- a/src/data/roadmap.ts
+++ b/src/data/roadmap.ts
@@ -189,6 +189,11 @@ export const roadmap: Roadmap = {
               href: '/leaves/engineering/slo-engineering/',
             },
             {
+              id: 'composite-slo-methodology',
+              label: 'Composite SLO Methodology',
+              href: '/leaves/engineering/composite-slo-methodology/',
+            },
+            {
               id: 'capacity-planning',
               label: 'Capacity Planning',
               href: '/leaves/engineering/capacity-planning/',


### PR DESCRIPTION
## Summary

**Последний лист из изначального плана 10 новых листьев.** После batch-1 (PR #64), batch-2 (PR #65) и batch-3 (PR #66) — десятый, и план закрыт целиком.

**Лист:**

- **engineering/composite-slo-methodology** — математика multi-component SLO. Когда «хочется четыре девятки» сталкивается с реальностью composite. Содержание:
  - Serial vs parallel dependencies — главное место ошибок (multiply blindly vs реальные fallback paths)
  - Vendor SLA как **floor**, не expectation (SLA — contractual minimum vendor готов компенсировать; planning под него, не под observed uptime)
  - Mandatory vs best-effort dependencies (observability backplane не в composite, auth/payment — да)
  - Journey-level SLI vs component-level composite (один сервис обслуживает несколько journeys, каждый со своим composite path)
  - Refresh после каждой major dependency change
  - Multi-burn-rate per journey, не per component

  **Публичный кейс:** типовое AWS приложение в одном регионе — ALB (99.99%) → EC2 (99.99%) → RDS Multi-AZ (99.95%) → S3 (99.9%) для статики → composite serial **99.83%**. Многие команды декларируют 99.95%+ без composite math, и первый dependency outage сжигает quarterly error budget. Hidalgo «Implementing SLOs» гл. 11 + Marc Brooker «Combining SLAs» (AWS blog) — практические референсы.

  SFIA L4-L6+. Размещение: Engineering / Reliability Engineering (5-й лист под L1, рядом с SLO Engineering, Capacity Planning, Resilience Patterns, Chaos Engineering).

**Cross-ссылки в смежных листьях:**
- \`slo-engineering\` → \`composite-slo-methodology\` (заменён open question «Composite SLO methodology — нет канонической формулы»)
- \`vendor-management\` → \`composite-slo-methodology\` (заменён TBD из open questions)

**Обновлено:**
- \`astro.config.mjs\` sidebar — пункт после \`SLO Engineering\` в Reliability Engineering группе
- \`src/data/roadmap.ts\` — новый leaf-узел
- \`sre-engineering.mdx\` — L2-список Reliability Engineering +Composite SLO Methodology, бюджет узлов 44→45
- \`README.md\` — Engineering 19→20 (всего: 44→45 листов)

## Итог изначального плана

После мержа этого PR:

| Batch | PR | Листья | L1 changes |
|---|---|---|---|
| 1 | #64 | Cost Management, Communities of Practice, Action Items Tracking | +L1 Financial Management (Engineering) |
| 2 | #65 | Symptom vs Cause Alerting, Change Governance, Vendor Management | +L1 Sourcing (Practices) |
| 3 | #66 | Shell & CLI Craft, Performance & Profiling, Operating Systems | +L2 Performance & Profiling в Programming/Scripting |
| 4 | этот | Composite SLO Methodology | +L2 Composite SLO Methodology в Reliability Engineering |

**10 новых листьев / 4 PR / 2 новых L1 / 2 новых L2.**

После мержа: Culture 8 + Engineering 20 + Practices 17 = **45 листьев полной глубины**.

## Test plan

- [x] \`npx astro build\` — clean, 55 страниц без ошибок
- [x] \`/leaves/engineering/composite-slo-methodology/\` строится
- [ ] Визуально проверить размещение в Reliability Engineering группе sidebar
- [ ] Проверить, что 2 cross-ссылки из \`slo-engineering\` и \`vendor-management\` работают
- [ ] \`BranchView\` корректно рендерит Reliability Engineering с 5 листами