### PR TITLE
docs(readme): статус roadmap — изначальный план закрыт

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ graph LR
 
 Последовательность развития компетенций и приоритеты (Must Have / Mandatory / Nice to have / On Demand) — на странице [/priorities/](https://jtprogru.github.io/The-Way-of-SRE/priorities/) сайта; определения осей — в [Методологии](https://jtprogru.github.io/The-Way-of-SRE/methodology/).
 
+Изначальный план новых листьев (10 шт) закрыт; следующая фаза — листья из open-questions / TBD-маркеров уже существующих.
+
 ## Локальный запуск сайта
 
 Проект — Astro Starlight. Команды доступны через [Task](https://taskfile.dev/):


### PR DESCRIPTION
## Summary
- В секцию `## Roadmap` добавлена одна строка: изначальный план новых листьев (10/10) закрыт, следующая фаза — листья из open-questions / TBD-маркеров существующих.
- Числа листьев (8/20/17 = 45) уже актуальны, не правлю.
- Формальных GitHub-milestone'ов в репозитории нет (проверил `gh api …/milestones`), отдельная дата не добавляется намеренно.

## Test plan
- [ ] Прочитать README в GitHub UI — Roadmap-секция читается, mermaid-схема и счётчики без регрессий.