### PR TITLE
feat(culture): добавить лист Game Day / Chaos Drills под Learning Delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ graph LR
     click SREPractices "https://jtprogru.github.io/The-Way-of-SRE/sre-practices/" "Перейти к SRE Practices"
 ```
 
-- **[SRE Culture](https://jtprogru.github.io/The-Way-of-SRE/sre-culture/)** — нормы, отношения, обмен опытом. Главный объект — люди и нормы. **9 листьев** на полной глубине.
+- **[SRE Culture](https://jtprogru.github.io/The-Way-of-SRE/sre-culture/)** — нормы, отношения, обмен опытом. Главный объект — люди и нормы. **10 листьев** на полной глубине.
 - **[SRE Engineering](https://jtprogru.github.io/The-Way-of-SRE/sre-engineering/)** — технические компетенции и стек. Главный объект — системы. **23 листа** на полной глубине.
 - **[SRE Practices](https://jtprogru.github.io/The-Way-of-SRE/sre-practices/)** — операционные процессы и ритуалы. Главный объект — процесс. **23 листа** на полной глубине.
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -67,6 +67,7 @@ export default defineConfig({
                 { label: 'DORA Metrics', link: '/leaves/culture/dora-metrics/' },
                 { label: 'Runbooks', link: '/leaves/culture/runbooks/' },
                 { label: 'Postmortem Culture', link: '/leaves/culture/postmortem-culture/' },
+                { label: 'Game Day / Chaos Drills', link: '/leaves/culture/game-day/' },
                 { label: 'Communities of Practice', link: '/leaves/culture/communities-of-practice/' },
                 { label: 'Dev Team Partnership', link: '/leaves/culture/dev-team-partnership/' },
                 { label: 'Service Ownership', link: '/leaves/culture/service-ownership/' },

--- a/src/content/docs/leaves/culture/game-day.md
+++ b/src/content/docs/leaves/culture/game-day.md
@@ -1,0 +1,90 @@
+---
+title: Game Day / Chaos Drills
+description: Регулярная тренировка incident response командой — про мышечную память и калибровку, не про разовое мероприятие к OKR
+---
+
+:::note[Метаданные листа]
+- **Ветвь:** Culture
+- **Путь:** Learning Delivery / Game Day / Chaos Drills
+- **SFIA-уровни:** 3, 4, 5, 6
+- **Приоритет:** Must Have
+- **Статус:** draft
+:::
+
+«Game day мы провели в прошлом году, всем понравилось, отметили в OKR» — фраза, которую я слышу регулярно. Это не game day, это event для отчёта. Game day работает только как **регулярный ритуал**: ежемесячный для команды, ежеквартальный для cross-team, ежегодный full-scale на уровне org. Цель — не «найти баги» и не «проверить chaos tooling». Цель — превратить incident response из теоретического знания в **мышечную память**, удержать calibration команды по мере смены людей и инфраструктуры, найти gaps в runbook'ах и observability до того, как их найдёт production. Лист — про культурную сторону практики; про **метод проверки гипотез о системе** — соседний лист [Chaos Engineering](/The-Way-of-SRE/leaves/engineering/chaos-engineering/).
+
+Game day и chaos engineering — разные инструменты с пересекающимся scope. Chaos engineering — **метод**: hypothesis-driven эксперимент, который может проводиться automated и continuous, без участия команды. Game day — **ритуал**: запланированное событие, на котором команда играет реакцию на инцидент. Game day может использовать chaos tooling (Chaos Mesh, AWS FIS), а может быть полностью tabletop / Wheel of Misfortune без единой инъекции. Граница не «технически vs организационно», а «**метод проверки системы** vs **тренировка команды**».
+
+## Что должен уметь
+
+Главный навык на уровне L5 — **проектировать game day так, чтобы сценарий учил, а не превращался в шоу**. Я регулярно вижу две крайности: либо сценарий тривиальный («перезагрузим pod, посмотрим как HPA отработает») и команда теряет интерес ко второй итерации, либо сценарий нагромождён («кладём БД + DNS + Kafka одновременно») и команда теряет понимание, что именно она сейчас тренирует. Хороший сценарий тренирует **одну явную способность** (escalation discipline, runbook execution, comms cadence, role handoff) и оставляет место для realistic confusion, но не для коллапса.
+
+- **L3** — Понимает разницу между game day, wheel of misfortune и chaos experiment. Участвует в game day своей команды как responder.
+- **L3** — Читает runbook'и заранее перед game day; в момент тренировки следует им, фиксирует места, где runbook был неясен или устарел.
+- **L4** — Фасилитирует Wheel of Misfortune для своей команды: выбирает прошлый или придуманный инцидент, описывает входной сигнал, ведёт обсуждение, фиксирует «что бы вы сделали → почему → откуда узнаете, что сработало».
+- **L4** — Готовит staging-сценарий: injection (через chaos tooling или вручную), observability checklist для проверки signal, runbook walk-through, abort-condition, post-game review template.
+- **L5** — Проектирует quarterly game day календарь для команды: scenarios варьируются (network / dependency / data / human-error / process), сложность растёт инкрементально, каждый game day тренирует одну явную способность.
+- **L5** — Запускает game day в production с minimal blast radius (1% traffic / 1 instance / single region) с явными abort-conditions и observability gates. Только когда staging-цикл стабильно работает.
+- **L5** — Ведёт post-game review: factual timeline, findings (что сработало / что нет), action items с владельцем и дедлайном; следит за их закрытием до следующего game day.
+- **L6+** — Внедряет game day как регулярную практику в нескольких командах / org-wide. Согласует cadence, scenarios sharing, cross-team drill, executive buy-in.
+- **L6+** — Проектирует full-scale exercise (DiRT-style): multi-team, multi-day, multi-region. Включая communications protocol, command center, regulatory implications.
+
+## Материалы
+
+### Книги
+
+- Betsy Beyer et al. — **[Site Reliability Engineering](https://sre.google/sre-book/accelerating-sre-on-call/)** (O'Reilly, 2016), глава 28 «Accelerating SREs to On-Call and Beyond». Источник Wheel of Misfortune как формализованной практики; читать первым, если впервые сталкиваетесь с темой.
+- Casey Rosenthal, Nora Jones — **[Chaos Engineering: System Resiliency in Practice](https://www.oreilly.com/library/view/chaos-engineering/9781492043858/)** (O'Reilly, 2020), главы про GameDay structure и blast radius management. Главный практический источник по технической стороне drill'ов с реальной инъекцией.
+- Kripa Krishnan — **[Weathering the Unexpected](https://queue.acm.org/detail.cfm?id=2371516)** (ACM Queue, 2012). Не книга, но обязательная статья: как Google запустил DiRT и что из этого вышло. Самый ценный единичный источник про full-scale drill.
+
+### Статьи и доклады
+
+- **[Wheel of Misfortune](https://landing.google.com/sre/workbook/chapters/training-site-reliability-engineers/)** (Google SRE Workbook). Описание формата, шаблоны сценариев, role facilitator. Стартовая точка для команды, у которой ещё нет ритуала.
+- **[AWS GameDay](https://aws.amazon.com/gameday/)** — программа AWS для внешнего обучения incident response. Полезна как **референс формата** (timeboxed, scoring, post-game debrief), даже если не используете AWS напрямую.
+- Aaron Blohowiak (Netflix) — **[FIT: Failure Injection Testing](https://netflixtechblog.com/fit-failure-injection-testing-35d8e2a9bb2)** (Netflix Tech Blog, 2014). Эволюция от game day к continuous chaos; объясняет, **где game day упирается в потолок** и нужны automated experiments.
+- Jason Yip — **[Game Days at LinkedIn](https://www.infoq.com/articles/linkedin-gameday/)**. Один из немногих публичных взглядов изнутри на cadence, scoring, action items follow-through.
+
+### Инструменты
+
+- **Markdown-сценарий в git** — основной артефакт game day: входной сигнал, expected runbook, abort-conditions, observability checklist, scoring rubric. Без документа сценарий разваливается на устные договорённости и не воспроизводится через квартал.
+- **[postmortem-templates](https://github.com/dastergon/postmortem-templates)** — публичные постмортемы как источник сценариев. По моим наблюдениям, лучшие game day-сценарии — это реальные инциденты других компаний, адаптированные под свой стек. Дешевле и реалистичнее, чем выдумывать.
+- **[Chaos Mesh](https://chaos-mesh.org/) / [AWS Fault Injection Service](https://aws.amazon.com/fis/)** — chaos tooling для game day с реальной инъекцией. См. [Chaos Engineering](/The-Way-of-SRE/leaves/engineering/chaos-engineering/) — там подробно про выбор. Для game day важна **safety-сторона**: явный abort-condition и фиксированный blast radius, не «посмотрим как пойдёт».
+- **PagerDuty / Opsgenie на test-сервисе** — отдельный test-pager для game day, чтобы не путать сигналы. Реальный alert flow → реальный pager → real-feel response.
+- **Tabletop-формат без tooling** — лист бумаги, facilitator, команда вокруг стола. Wheel of Misfortune в чистом виде. Самый дешёвый и при этом один из самых эффективных game day-форматов. Не недооценивать.
+
+## Best practices
+
+Главный публичный кейс — **Google DiRT (Disaster Recovery Testing)**. Kripa Krishnan описывает в ACM Queue 2012, как Google ежегодно проводит full-scale exercise: команды отключают сервисы, тренируют коммуникации, проверяют business continuity на масштабе всей компании. DiRT — не chaos engineering и не continuous: это **запланированный ритуал** с командным центром, расписанием, ролями, и (главное) executive buy-in. Из его уроков несколько универсальных: (1) findings без owner'а и дедлайна не закрываются; (2) сценарии нужно ротировать, иначе команда натренирована только на знакомые failure modes; (3) tabletop-вариант DiRT (без реальной инъекции) даёт 60-70% ценности за 10% стоимости. Если читаете лист и планируете first game day — сначала статью Krishnan, потом сюда.
+
+**Короткие правила:**
+
+- **Game day — это ритуал, не разовая активность к OKR.** Single-shot game day не строит мышечную память и не калибрует команду по мере смены людей. Антипаттерн: «провели в прошлом квартале, теперь продолжим в этом году». Правильно — фиксированный календарь, ритм месяц/квартал, scenarios варьируются.
+- **Один game day — одна явная цель тренировки.** «Кладём всё одновременно, посмотрим что выйдет» — команда теряет понимание, что именно она тренирует, и не извлекает уроки. Каждый сценарий тренирует **одну способность** (escalation, runbook execution, comms cadence, role handoff). Можно усложнять между game day'ями, но не внутри одного.
+- **Abort-condition и blast radius — до начала, не в моменте.** Когда «ой, что-то не так» происходит в моменте game day, единственный способ безопасно остановиться — заранее зафиксированный abort: SLO burn rate > X, error rate > Y, customer impact detected → немедленный stop, cleanup, debrief. Без abort game day превращается в real incident.
+
+Подробнее:
+
+**Wheel of Misfortune — недооценённый формат.** Я регулярно вижу команды, которые сразу пытаются «по-взрослому» — staging с chaos tooling, на полдня, с full observability. Это дорого, требует инфраструктуры и часто не запускается из-за этого. Tabletop-вариант (Wheel of Misfortune из SRE Workbook гл. 28) — facilitator описывает входной alert, команда обсуждает «что бы вы сделали → откуда узнаете, сработало ли». Час времени, ноль инфраструктуры. Я считаю, что для команды, у которой game day ещё нет, единственный осмысленный первый шаг — это месяц tabletop'ов перед попыткой staging-injection. Дешевизна = регулярность; регулярность = ритуал; ритуал = мышечная память.
+
+**Post-game review важнее самой тренировки.** Самая частая поломка ритуала, которую я наблюдаю: game day прошёл, всем понравилось, findings записаны в Slack-канал, никто не возвращается. Через квартал команда не помнит ни findings, ни почему runbook был неясен. Структура работающего review: factual timeline, что сработало / что нет, runbook updates, observability gaps, action items с владельцем и дедлайном. На следующем game day первый пункт — review action items от прошлого. Без этой петли game day становится развлечением.
+
+**Game day для всей команды, не только для onboardee.** Wheel of Misfortune часто воспринимают как onboarding-инструмент (см. [SRE Onboarding](/The-Way-of-SRE/leaves/culture/sre-onboarding/)) — что правильно, но это часть ценности. Основная — это **continuous calibration существующей команды**. People drift away from process, runbook'и устаревают вместе с инфраструктурой, observability gap'ы накапливаются. Без регулярной тренировки команда теряет skill, не замечая этого, и обнаруживает потерю на real incident в 3 ночи. Регулярный game day — это аналог fire drill в офисе: участвуют все, не только новички.
+
+**Cultural prerequisites: blameless, postmortem, runbook discipline.** Те же три предпосылки, что и для chaos engineering (см. соседний лист). Если в команде game day finding превращается в «кто пропустил это в runbook» — feedback loop сломан, и через 2-3 game day'я команда перестанет серьёзно участвовать. Pre-check адопции в порядке: [blameless-постмортем](/The-Way-of-SRE/leaves/practices/blameless-postmortem/) → working runbook practice → game day. Без первых двух game day превращается в blame-генератор и теряет смысл за квартал.
+
+## Связанные листья
+
+- **[Chaos Engineering](/The-Way-of-SRE/leaves/engineering/chaos-engineering/)** — метод проверки гипотез о системе; может использоваться в game day, но scope шире (continuous, automated). Game day — ритуал, chaos — метод; пересекаются, но не дублируются.
+- **[Incident Response](/The-Way-of-SRE/leaves/practices/incident-response/)** — game day тренирует **именно этот процесс**: роли, escalation, sitrep, mitigation vs investigation. Без working incident response practice game day не имеет, что тренировать.
+- **[SRE Onboarding](/The-Way-of-SRE/leaves/culture/sre-onboarding/)** — Wheel of Misfortune для onboardee — частный случай game day. Здесь — про continuous calibration команды, там — про скрипт первых недель.
+- **[Postmortem Culture](/The-Way-of-SRE/leaves/culture/postmortem-culture/)** — game day findings обрабатываются через постмортем-формат; качество разборов = качество сценариев для будущих drill'ов.
+- **[Runbooks](/The-Way-of-SRE/leaves/culture/runbooks/)** — game day — основной механизм валидации runbook'ов: если шаги не сработали — runbook outdated. Без drill'а вы узнаёте об этом в реальном инциденте.
+- **[Severity Classification](/The-Way-of-SRE/leaves/practices/severity-classification/)** — scenarios варьируются по severity; game day тренирует correct severity declaration без давления реального инцидента.
+- **[On-Call Rotation](/The-Way-of-SRE/leaves/practices/on-call-rotation/)** — game day с participation новых on-call inженеров — основная подготовка перед первой неделей; снижает MTTR и тревожность.
+- **[Communities of Practice](/The-Way-of-SRE/leaves/culture/communities-of-practice/)** — cross-team game day и sharing сценариев между командами — типичная активность CoP по reliability.
+
+## Открытые вопросы
+
+- **Full-scale DR exercise (DiRT-style) как отдельный лист** *(TBD)* — multi-team, multi-day, multi-region drill. Своя сложность (command center, executive buy-in, regulatory exposure, business continuity scope), которая не помещается в team-level game day. Может стать отдельным листом под IT Management / DR Policy & Stakeholders.
+- Cadence на команду (раз в месяц / квартал / полугодие) зависит от размера команды, ротации on-call, скорости изменений инфраструктуры. Универсальной формулы я не нашёл; квартальный встречается чаще всего.
+- Я не уверен, как корректно проводить game day в командах, где on-call rotation 24/7 и любой scheduled drill совпадает с реальной нагрузкой. Возможно, ответ — async tabletop-формат, но рабочей публичной практики я не видел. Если есть опыт — расскажите PR'ом.

--- a/src/content/docs/leaves/culture/postmortem-culture.md
+++ b/src/content/docs/leaves/culture/postmortem-culture.md
@@ -72,6 +72,7 @@ description: Норма безвиновного разбора инцидент
 - **[SLO / Budget Review](/The-Way-of-SRE/leaves/culture/slo-budget-review/)** — постмортемы выявляют источники сжигания бюджета; ритуал ревью — точка, где lessons learned превращаются в приоритеты.
 - **[Runbooks](/The-Way-of-SRE/leaves/culture/runbooks/)** — каждый постмортем должен порождать обновление runbook; иначе lesson learned не закреплён.
 - **[Dev Team Partnership](/The-Way-of-SRE/leaves/culture/dev-team-partnership/)** — joint postmortem с product-командой — обязательное условие сохранения partnership.
+- **[Game Day / Chaos Drills](/The-Way-of-SRE/leaves/culture/game-day/)** — game day findings обрабатываются через постмортем-формат; cultural prerequisite адопции — работающая blameless-норма.
 
 ## Открытые вопросы
 

--- a/src/content/docs/leaves/culture/sre-onboarding.md
+++ b/src/content/docs/leaves/culture/sre-onboarding.md
@@ -71,6 +71,7 @@ description: Систематическое введение нового SRE �
 - **[Service Ownership](/The-Way-of-SRE/leaves/culture/service-ownership/)** — service catalog — точка входа onboardee в production.
 - **[Career Ladders](/The-Way-of-SRE/leaves/culture/career-ladders/)** — onboarding curriculum обычно maps к L3 → L4 progression в первый год.
 - **[Communities of Practice](/The-Way-of-SRE/leaves/culture/communities-of-practice/)** — после первых 12 недель CoP — место, где новый инженер находит cross-team peer learning.
+- **[Game Day / Chaos Drills](/The-Way-of-SRE/leaves/culture/game-day/)** — Wheel of Misfortune для onboardee — частный случай. Здесь — onboarding-скрипт первых недель; там — continuous calibration команды.
 
 ## Открытые вопросы
 

--- a/src/content/docs/leaves/engineering/chaos-engineering.md
+++ b/src/content/docs/leaves/engineering/chaos-engineering.md
@@ -81,10 +81,10 @@ description: Hypothesis-driven эксперименты для проверки 
 - **[Runbooks](/The-Way-of-SRE/leaves/culture/runbooks/)** — game day валидирует runbook'и: если шаги не сработали, runbook outdated.
 - **[Severity Classification](/The-Way-of-SRE/leaves/practices/severity-classification/)** — game day scenarios варьируются по severity, тренируют correct severity declaration.
 - **[Security Chaos Engineering](/The-Way-of-SRE/leaves/practices/security-chaos-engineering/)** — тот же метод, объект — security-контролы вместо reliability-свойств: проверяем, срабатывает ли detection / response, а не остаётся ли система живой.
+- **[Game Day / Chaos Drills](/The-Way-of-SRE/leaves/culture/game-day/)** — chaos engineering = метод проверки гипотез о системе; game day = ритуал тренировки команды. Пересекаются по tooling, но разные по scope: continuous / automated chaos vs scheduled team drill.
 
 ## Открытые вопросы
 
-- **Continuous Chaos vs GameDay** — scheduled monthly GameDay (low-cost / high-engagement) vs continuous chaos в pipeline (high-confidence / catches regressions). Возможно отдельный лист на детализацию.
 - **Disaster Recovery Testing** *(TBD)* — DR drills (regional failover, DB failure, full data center loss) — большие chaos experiments верхнего уровня со своим scope и cadence.
 - **Security Chaos Engineering** — выделен в отдельный лист (Practices / Information Security; см. Связанные листья).
 - **Failure Modes Catalog** *(TBD)* — систематический каталог known failure modes для сервиса/системы как корень chaos scenarios.

--- a/src/content/docs/leaves/practices/incident-response.md
+++ b/src/content/docs/leaves/practices/incident-response.md
@@ -78,6 +78,7 @@ description: Координация реагирования на инциден
 - **[Action Items Tracking](/The-Way-of-SRE/leaves/practices/action-items-tracking/)** — close-out incident включает создание AIs с owner / deadline / criterion; этот лист — про дисциплину их выполнения.
 - **[ChatOps](/The-Way-of-SRE/leaves/engineering/chatops/)** — современные incident-инструменты (incident.io, Netflix Dispatch, FireHydrant) — Slack-native ChatOps; declare / coordinate / sitrep живут в chat с встроенным audit trail.
 - **[Status Page Management](/The-Way-of-SRE/leaves/practices/status-page-management/)** — public status page update — часть IC checklist в моменте инцидента.
+- **[Game Day / Chaos Drills](/The-Way-of-SRE/leaves/culture/game-day/)** — регулярная тренировка этого процесса до того, как он понадобится; разница в MTTR между командами с game day и без — 2–3 раза.
 
 ## Открытые вопросы
 

--- a/src/content/docs/leaves/practices/on-call-rotation.md
+++ b/src/content/docs/leaves/practices/on-call-rotation.md
@@ -74,6 +74,7 @@ description: Организация дежурства команды — кто
 - **[SRE Onboarding](/The-Way-of-SRE/leaves/culture/sre-onboarding/)** — supervised on-call как мост от curriculum к самостоятельной ротации.
 - **[One-on-Ones](/The-Way-of-SRE/leaves/practices/one-on-ones/)** — discussion on-call health на 1:1 — встроенный sustainability check.
 - **[ChatOps](/The-Way-of-SRE/leaves/engineering/chatops/)** — `/oncall`, `/escalate`, `/page` через chat — стандартные ChatOps queries и actions для on-call workflow.
+- **[Game Day / Chaos Drills](/The-Way-of-SRE/leaves/culture/game-day/)** — game day с participation новых on-call инженеров — основная подготовка перед первой неделей; снижает MTTR и тревожность.
 
 ## Открытые вопросы
 

--- a/src/data/roadmap.ts
+++ b/src/data/roadmap.ts
@@ -92,6 +92,12 @@ export const roadmap: Roadmap = {
               priority: 'must',
             },
             {
+              id: 'game-day',
+              label: 'Game Day / Chaos Drills',
+              href: '/leaves/culture/game-day/',
+              priority: 'must',
+            },
+            {
               id: 'communities-of-practice',
               label: 'Communities of Practice',
               href: '/leaves/culture/communities-of-practice/',


### PR DESCRIPTION
## Summary

Закрывает явный пробел в Culture / Learning Delivery: game day как **регулярный ритуал тренировки команды**, не разовая активность к OKR. Чёткая граница со [Chaos Engineering](https://github.com/jtprogru/The-Way-of-SRE/blob/main/src/content/docs/leaves/engineering/chaos-engineering.md) (метод проверки гипотез о системе) и [Incident Response](https://github.com/jtprogru/The-Way-of-SRE/blob/main/src/content/docs/leaves/practices/incident-response.md) (реальный процесс реагирования; game day тренирует именно его).

## Изменения

- `src/content/docs/leaves/culture/game-day.md` — новый лист (Must Have, SFIA 3–6). Lead — про game day как event-для-отчёта vs ритуал. Public-кейс — Google DiRT (Krishnan, ACM Queue 2012). Taxonomy форматов: Wheel of Misfortune (tabletop) → staging functional drill → production drill с minimal blast radius → full-scale DiRT-style.
- `src/data/roadmap.ts` + `astro.config.mjs` — регистрация под `learning-delivery` L1.
- `README.md` — счётчик Culture 9 → 10.
- Cross-refs: добавлены back-links в `chaos-engineering.md`, `incident-response.md`, `sre-onboarding.md`, `on-call-rotation.md`, `postmortem-culture.md`. В `chaos-engineering.md` снят TBD «Continuous Chaos vs GameDay» — раскрыт новым листом.

## Эффект

- **Culture теперь 10 листьев** (Learning Delivery 2 → 3). Состояние: 56 листьев (10/23/23).
- Снят 1 TBD-маркер.
- DR Testing остаётся TBD в обоих листах (chaos-engineering + game-day) — намеренно, кандидат на отдельный лист под IT Management / DR Policy & Stakeholders.

## Test plan

- [x] `npm run build` — без ошибок, 66 страниц.
- [ ] Визуально проверить, что лист отображается в sidebar и на карте.
- [ ] Проверить cross-link'и из Chaos Engineering / Incident Response / SRE Onboarding / On-Call Rotation / Postmortem Culture.