### PR TITLE
feat(culture): Knowledge Management batch — Playbooks + Postmortem Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ graph LR
     click SREPractices "https://jtprogru.github.io/The-Way-of-SRE/sre-practices/" "Перейти к SRE Practices"
 ```
 
-- **[SRE Culture](https://jtprogru.github.io/The-Way-of-SRE/sre-culture/)** — нормы, отношения, обмен опытом. Главный объект — люди и нормы. **11 листьев** на полной глубине.
+- **[SRE Culture](https://jtprogru.github.io/The-Way-of-SRE/sre-culture/)** — нормы, отношения, обмен опытом. Главный объект — люди и нормы. **13 листьев** на полной глубине.
 - **[SRE Engineering](https://jtprogru.github.io/The-Way-of-SRE/sre-engineering/)** — технические компетенции и стек. Главный объект — системы. **23 листа** на полной глубине.
 - **[SRE Practices](https://jtprogru.github.io/The-Way-of-SRE/sre-practices/)** — операционные процессы и ритуалы. Главный объект — процесс. **23 листа** на полной глубине.
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -66,6 +66,8 @@ export default defineConfig({
                 { label: 'SLO / Budget Review', link: '/leaves/culture/slo-budget-review/' },
                 { label: 'DORA Metrics', link: '/leaves/culture/dora-metrics/' },
                 { label: 'Runbooks', link: '/leaves/culture/runbooks/' },
+                { label: 'Playbooks', link: '/leaves/culture/playbooks/' },
+                { label: 'Postmortem Database', link: '/leaves/culture/postmortem-database/' },
                 { label: 'Postmortem Culture', link: '/leaves/culture/postmortem-culture/' },
                 { label: 'Game Day / Chaos Drills', link: '/leaves/culture/game-day/' },
                 { label: 'Communities of Practice', link: '/leaves/culture/communities-of-practice/' },

--- a/src/content/docs/glossary.mdx
+++ b/src/content/docs/glossary.mdx
@@ -344,11 +344,17 @@ Kubernetes controller с custom CRD, который управляет complex /
 
 ## P
 
+### playbook
+
+Сценарий реагирования для **класса** инцидентов: роли (IC / Deputy / Scribe / SME), первые действия, decision points, escalation criteria, comms cadence. Не путать с [runbook](#runbook): runbook = «что делать» для одного симптома; playbook = «что решать и кого звать» для класса инцидентов. Google SRE Workbook использует термины как синонимы; incident-response сообщество после PagerDuty / incident.io в 2020-х закрепило различение.
+
+*Категория A*. См. [`Playbooks`](/The-Way-of-SRE/leaves/culture/playbooks/), [`Runbooks`](/The-Way-of-SRE/leaves/culture/runbooks/), [`Incident Response`](/The-Way-of-SRE/leaves/practices/incident-response/).
+
 ### postmortem
 
 Документ, фиксирующий разбор инцидента после его завершения: timeline, contributing factors, action items с владельцем и дедлайном, lessons learned. В SRE-практике норма — [blameless](#blameless) постмортем.
 
-*Категория A* как документ; «провести разбор» допустим как процесс. См. [`Postmortem Culture`](/The-Way-of-SRE/leaves/culture/postmortem-culture/), [`Blameless Postmortem`](/The-Way-of-SRE/leaves/practices/blameless-postmortem/). Источник: Beyer et al., *SRE Book*, гл. 15.
+*Категория A* как документ; «провести разбор» допустим как процесс. См. [`Postmortem Culture`](/The-Way-of-SRE/leaves/culture/postmortem-culture/), [`Blameless Postmortem`](/The-Way-of-SRE/leaves/practices/blameless-postmortem/), [`Postmortem Database`](/The-Way-of-SRE/leaves/culture/postmortem-database/). Источник: Beyer et al., *SRE Book*, гл. 15.
 
 ### principle of least privilege
 

--- a/src/content/docs/leaves/culture/game-day.md
+++ b/src/content/docs/leaves/culture/game-day.md
@@ -82,6 +82,8 @@ Game day и chaos engineering — разные инструменты с пер�
 - **[Severity Classification](/The-Way-of-SRE/leaves/practices/severity-classification/)** — scenarios варьируются по severity; game day тренирует correct severity declaration без давления реального инцидента.
 - **[On-Call Rotation](/The-Way-of-SRE/leaves/practices/on-call-rotation/)** — game day с participation новых on-call inженеров — основная подготовка перед первой неделей; снижает MTTR и тревожность.
 - **[Communities of Practice](/The-Way-of-SRE/leaves/culture/communities-of-practice/)** — cross-team game day и sharing сценариев между командами — типичная активность CoP по reliability.
+- **[Postmortem Database](/The-Way-of-SRE/leaves/culture/postmortem-database/)** — главный источник сценариев game day; реальные прошлые инциденты лучше любых вымышленных.
+- **[Playbooks](/The-Way-of-SRE/leaves/culture/playbooks/)** — playbook без training работает один раз; game day — место, где playbook'и тренируются и обнаруживаются их пропуски.
 
 ## Открытые вопросы
 

--- a/src/content/docs/leaves/culture/playbooks.md
+++ b/src/content/docs/leaves/culture/playbooks.md
@@ -1,0 +1,86 @@
+---
+title: Playbooks
+description: Сценарии реагирования на класс инцидентов с явными ролями, decision points и cadence — про координацию, не про команды
+---
+
+:::note[Метаданные листа]
+- **Ветвь:** Culture
+- **Путь:** Knowledge Management / Playbooks
+- **SFIA-уровни:** 3, 4, 5, 6
+- **Приоритет:** Mandatory
+- **Статус:** draft
+:::
+
+«Playbook и [runbook](/The-Way-of-SRE/glossary/#runbook) — это одно и то же?» — вопрос, который я слышу почти от каждой команды, у которой первый раз появляется инцидент с двумя командами в war room. Терминология в индустрии действительно плавающая: Google SRE Workbook называет «playbook» то, что DevOps-индустрия обычно называет runbook. Я придерживаюсь различения, которое закрепилось в incident-response сообществе после PagerDuty / incident.io в 2020-х: **runbook — это конкретные шаги для одного симптома** («увидел 5xx > 1% → выполни шаги 1-N»); **playbook — это сценарий реагирования для класса инцидентов** с ролями, decision points, cadence, escalation. Лист — про playbook'и; про runbook'и — соседний лист [Runbooks](/The-Way-of-SRE/leaves/culture/runbooks/), который явно вынес обсуждение границы как TBD; этот лист её закрывает.
+
+Один способ почувствовать разницу: на инциденте «data corruption в primary DB» runbook ответит на вопросы «как проверить целостность? как переключиться на реплику?». Playbook ответит на вопросы «кого позвать? что говорим клиентам сейчас и через час? в какой момент решаем не восстанавливать данные, а пересоздать таблицу? кто принимает решение?». Это разные документы и разные навыки. Runbook читает on-call инженер; playbook читает Incident Commander.
+
+## Что должен уметь
+
+Главный навык на уровне L5 — **проектировать playbook так, чтобы он работал при стрессе IC, а не выглядел красиво на ревью**. Я регулярно вижу 12-страничные playbook'и с decision matrix на 30 строк — они не открываются в моменте инцидента, потому что IC не успевает их прочитать. Хороший playbook помещается на одну страницу для quick reference: роли (2-3 строки), первые действия (5-7 шагов), decision points (3-4 явных вопроса), escalation (когда + кому), comms cadence (когда обновлять статус). Всё остальное — в приложениях, которые открываются по ссылке.
+
+- **L3** — Понимает разницу между playbook и runbook; знает, какие playbook'и команда использует; следует роли, назначенной в playbook (responder, scribe, comms).
+- **L4** — Пишет playbook для известного класса инцидентов своего сервиса: роли, первые действия, decision points, escalation criteria, comms cadence. Обновляет после каждого инцидента, в котором playbook использовался.
+- **L4** — Различает severity-зависимые playbook'и: SEV1 playbook ≠ SEV3 playbook (разные роли, intensity, comms). Не использует один playbook на все severity.
+- **L5** — Проектирует семейство playbook'ов для команды/сервиса: incident response, security incident, data corruption, capacity emergency, vendor outage. Согласует общую структуру между ними.
+- **L5** — Встраивает playbook в incident workflow: ChatOps-команда (`/incident declare`) подтягивает playbook в war room channel, роли распределяются автоматически, checklist рендерится.
+- **L5** — Проводит quarterly review playbook'ов: какие открывались и как часто, какие шаги работали, какие — нет. Playbook без использования за полгода либо удаляется, либо инспектируется.
+- **L6+** — Внедряет playbook-практику на уровне org: единая структура, шаблоны, шаринг между командами, governance актуальности.
+- **L6+** — Связывает playbook с regulatory обязательствами там, где они есть (PCI-DSS incident response, GDPR breach notification, SOC 2): playbook — артефакт compliance, не только operational tool.
+
+## Материалы
+
+### Книги
+
+- Betsy Beyer et al. — **[The Site Reliability Workbook](https://sre.google/workbook/on-call/)** (O'Reilly, 2018), глава 8 «On-Call». Google использует «playbook» как обобщённый термин, но описанная структура (severity, impact, debugging suggestions, mitigation) практически совпадает с тем, что incident.io / PagerDuty называют playbook сегодня. Полезно как baseline.
+- Atlassian — **[Incident Management Handbook](https://www.atlassian.com/incident-management)** (живой документ). Самый детальный публичный гайд по структуре playbook'а в индустрии 2020-х. Главы по severity playbook, communications playbook, postmortem playbook читаются как референс.
+
+### Статьи и доклады
+
+- **[PagerDuty Incident Response Documentation](https://response.pagerduty.com/)**. Публично выложенный playbook PagerDuty: роли (IC, Deputy, Scribe, Subject Matter Experts), severity playbook, training playbook. По моим наблюдениям — самый часто адаптируемый референс в индустрии. Команды берут как стартовый template и подгоняют под себя.
+- **[Google SRE Book, Chapter 14 «Managing Incidents»](https://sre.google/sre-book/managing-incidents/)**. Принципы incident command (заимствованы из ICS — Incident Command System пожарной службы): clear roles, working in concert, calm under pressure. Это **философская основа** playbook'ов, читается до конкретных шаблонов.
+- **[incident.io Playbooks library](https://incident.io/blog/incident-playbooks)** — открытая библиотека playbook'ов от incident.io. По моим наблюдениям, лучший публичный источник конкретных шаблонов «для какой ситуации какой playbook». Берут как готовые стартовые точки, а не как finished documents.
+
+### Инструменты
+
+- **Markdown в репозитории команды** — базовый формат, как и для runbook'ов. PR-based review, git history, легко искать. Я регулярно вижу, что зрелые команды держат playbook'и в одном репо с runbook'ами, под разными директориями.
+- **[incident.io](https://incident.io/) / [FireHydrant](https://firehydrant.com/) / [Rootly](https://rootly.com/)** — incident management платформы, в которых playbook — first-class entity: декларация инцидента → автоматический выбор playbook → ролi распределяются в Slack → checklist рендерится в war room channel. По моим наблюдениям, оправданы в org от 50+ инженеров, где инциденты ≥ еженедельно. В команде из 10 человек — overengineering, markdown справится.
+- **[Netflix Dispatch](https://github.com/Netflix/dispatch)** — open-source альтернатива managed platforms. Playbook как код, интеграция со Slack / PagerDuty / Jira. Берут команды, которые не хотят SaaS-зависимости.
+- **ChatOps-команда `/incident declare <type>`** — самый частый способ привязать playbook к инциденту в моменте. Bot создаёт war room, постит первый чеклист, тегает IC. См. [ChatOps](/The-Way-of-SRE/leaves/engineering/chatops/) для деталей.
+
+## Best practices
+
+Главный публичный кейс — **PagerDuty Incident Response Documentation**. PagerDuty опубликовала свои внутренние playbook'и в 2017 году как open-source. На момент написания листа это самый цитируемый референс в индустрии: роли IC / Deputy / Scribe / SME, training playbook (как готовить новых IC), severity playbook с явной decision matrix, communications playbook. Уникальность этого источника не в том, что они «правильные» — а в том, что они **публично доступны и адаптируемы**. Команды берут их как baseline, подрезают под свою специфику (часть ролей объединяется, severity-уровни упрощаются), и через 2-3 итерации получают свой рабочий playbook без необходимости изобретать структуру с нуля. Если читаете лист и впервые внедряете playbook — начните с PagerDuty, дальше — incident.io библиотека.
+
+**Короткие правила:**
+
+- **Playbook — для класса инцидентов, не для одного.** Антипаттерн: один playbook на «любой инцидент». Правильно: семейство playbook'ов по типу (database, network, security, vendor, capacity) + по severity. Один playbook ≠ один инцидент, но один playbook = один **повторяющийся сценарий**.
+- **Playbook помещается на одну страницу для quick reference.** Антипаттерн: 12-страничный документ с матрицами. В моменте инцидента IC не читает 12 страниц. Правильно: одна страница для quick reference (роли, первые шаги, decision points, escalation, comms), остальное — в приложениях за ссылками.
+- **Severity-зависимый playbook, а не «один на все случаи».** SEV1 playbook включает executive notification, public status page, war room с 10+ людьми. SEV3 playbook — IC + один SME, тихо чинят, без эскалации. Использование SEV1 playbook на SEV3 → burnout команды; SEV3 playbook на SEV1 → missed escalation. Связь playbook ↔ severity явная.
+
+Подробнее:
+
+**Playbook без training работает только один раз.** Я регулярно вижу команды, у которых playbook'и записаны качественно, но в моменте инцидента IC не открывает их — потому что никогда не открывал раньше, не помнит структуры, ищет в Confluence по поиску. Playbook — это **muscle memory**: его открывают на каждом game day, прогоняют по ролям, обнаруживают пропуски. Без game day playbook остаётся знанием, не навыком. См. [Game Day / Chaos Drills](/The-Way-of-SRE/leaves/culture/game-day/) — там про training-сторону практики.
+
+**Decision points — главное, что отличает playbook от runbook.** Runbook отвечает на вопрос «что делать» (конкретные команды). Playbook отвечает на вопрос «**в какой момент** что решать» (decision points). Примеры decision points из playbook'ов, которые я видел работающими: «через 30 минут без mitigation — escalate к executive». «Если data loss > 5 минут — рассмотреть переключение на secondary с потерей данных vs восстановление primary». «Если customer impact > 10% и > 15 минут — public status page update». Это не runbook-шаги, это **явные точки принятия решения IC**, которые без playbook принимаются ad-hoc.
+
+**Playbook — артефакт постмортема, не запасной документ.** Самый частый источник update'ов playbook'а — это постмортемы. Шаг, который IC не помнил → новый decision point в playbook. Communication, которая дошла поздно → cadence updated. Эскалация, которая случилась поздно → escalation criteria уточнены. Playbook без regular updates устаревает быстрее runbook'а, потому что структура инцидентов меняется с изменением org. Я регулярно вижу playbook'и, которые ссылаются на роли (Director of Engineering), которых в org больше нет, или на каналы Slack, которые archived. Это не playbook, это исторический документ.
+
+**Severity-зависимая роль IC.** На SEV3 IC может быть on-call инженер, который ведёт инцидент сам. На SEV1 IC должен быть **выделенный человек**, не вовлечённый в техническое расследование. Это правило из ICS, которое чаще всего нарушают: IC и Ops Lead — один человек, в результате coordination проседает, communications отстают, escalation запаздывают. Playbook SEV1 явно фиксирует разделение ролей; SEV3 playbook — допускает совмещение.
+
+## Связанные листья
+
+- **[Runbooks](/The-Way-of-SRE/leaves/culture/runbooks/)** — runbook отвечает «как делать», playbook — «что решать и кого звать». Runbook'и встраиваются в playbook'и как ссылки на конкретные шаги; playbook без runbook — обещание, runbook без playbook — фрагмент.
+- **[Incident Response](/The-Way-of-SRE/leaves/practices/incident-response/)** — playbook'и — главный артефакт incident response practice; коэффициент использования playbook'ов — прямой индикатор зрелости IR.
+- **[Severity Classification](/The-Way-of-SRE/leaves/practices/severity-classification/)** — playbook выбирается по severity; чёткая severity matrix — предпосылка работающего playbook-семейства.
+- **[Customer Communications](/The-Way-of-SRE/leaves/practices/customer-communications/)** — comms cadence — часть playbook'а; severity-зависимая communications matrix живёт в playbook'е.
+- **[War Room Patterns](/The-Way-of-SRE/leaves/practices/war-room-patterns/)** — playbook включает war room setup (когда открывать, кого звать, как закрывать); pattern'ы war room — деталь playbook'а.
+- **[Game Day / Chaos Drills](/The-Way-of-SRE/leaves/culture/game-day/)** — playbook'и тренируются в game day; неоткрываемый playbook = не-навык.
+- **[ChatOps](/The-Way-of-SRE/leaves/engineering/chatops/)** — playbook'и привязываются к incident-инцидентам через ChatOps-команды (`/incident declare`); современные incident-платформы — Slack-native ChatOps.
+- **[Status Page Management](/The-Way-of-SRE/leaves/practices/status-page-management/)** — public status page update — шаг в comms-секции playbook'а; cadence обновлений живёт в playbook'е.
+
+## Открытые вопросы
+
+- **Industry-wide terminology** — несмотря на то, что incident-response сообщество явно различает runbook и playbook, академические источники (Google SRE Workbook) используют термины как синонимы. Если у вас в команде закрепился свой term — это нормально; **главное — явное определение в команде**, не «как у всех». Терминологический холивар не стоит того, чтобы из-за него playbook не был написан.
+- **Playbook как regulatory artifact** — PCI-DSS, GDPR, SOC 2 требуют документированных incident response plan. Я не уверен, как корректно совмещать operational playbook (короткий, рабочий) и compliance playbook (формальный, подробный). Скорее всего, это два документа с cross-link, но **рабочей публичной практики** на эту границу я не видел. Если есть опыт — расскажите PR'ом.
+- **Generative playbooks** — AI-ассистент, который генерирует начальный playbook на основе сервиса / архитектуры / past incidents. На начало 2026 года это активная область экспериментов (incident.io AI, FireHydrant AI), но рабочих кейсов в публичной литературе пока мало.

--- a/src/content/docs/leaves/culture/postmortem-culture.md
+++ b/src/content/docs/leaves/culture/postmortem-culture.md
@@ -73,6 +73,7 @@ description: Норма безвиновного разбора инцидент
 - **[Runbooks](/The-Way-of-SRE/leaves/culture/runbooks/)** — каждый постмортем должен порождать обновление runbook; иначе lesson learned не закреплён.
 - **[Dev Team Partnership](/The-Way-of-SRE/leaves/culture/dev-team-partnership/)** — joint postmortem с product-командой — обязательное условие сохранения partnership.
 - **[Game Day / Chaos Drills](/The-Way-of-SRE/leaves/culture/game-day/)** — game day findings обрабатываются через постмортем-формат; cultural prerequisite адопции — работающая blameless-норма.
+- **[Postmortem Database](/The-Way-of-SRE/leaves/culture/postmortem-database/)** — норма разбора (этот лист) vs система хранения и извлечения уроков. Без культуры database заполняется поверхностными документами; без database культура теряет 60-70% долгосрочной ценности.
 
 ## Открытые вопросы
 

--- a/src/content/docs/leaves/culture/postmortem-database.md
+++ b/src/content/docs/leaves/culture/postmortem-database.md
@@ -1,0 +1,88 @@
+---
+title: Postmortem Database
+description: Систематический архив постмортемов с поиском и тегированием — про распространение уроков, не про хранение
+---
+
+:::note[Метаданные листа]
+- **Ветвь:** Culture
+- **Путь:** Knowledge Management / Postmortem Database
+- **SFIA-уровни:** 3, 4, 5, 6
+- **Приоритет:** Mandatory
+- **Статус:** draft
+:::
+
+«У нас есть Confluence-папка с постмортемами» — это не postmortem database, это свалка. Я регулярно вижу команды, в которых архив постмортемов формально существует — Confluence space, Notion database, папка в git — но никто, кроме автора, никогда не открывает оригинал постмортема второй раз. Через год архив становится мусорным: одни и те же contributing factors всплывают в новых инцидентах, потому что прошлые уроки не нашли. Postmortem database — это **систематический архив с поиском, тегированием и регулярным review**, который превращает накопленные постмортемы в actionable knowledge. Граница с [Postmortem Culture](/The-Way-of-SRE/leaves/culture/postmortem-culture/) явная: тот лист — про **норму** разбора (как мы говорим про ошибки); этот — про **систему хранения и извлечения уроков** из того, что норма уже произвела.
+
+Я считаю, что без postmortem database постмортемная практика на 60-70% теряет ценность. Сам разбор полезен в моменте — команда учится, action items закрываются, runbook'и обновляются. Но через 2-3 года, при ротации людей, эти уроки забываются — новый инженер встречает контaminated database из past incidents и не находит, что нужная информация уже есть. База постмортемов с тегами и поиском — это **временной интерфейс** к опыту команды: уроки доступны не только тем, кто был в incident, но и тем, кто пришёл через два года.
+
+## Что должен уметь
+
+Главный навык на уровне L5 — **проектировать схему тегирования так, чтобы поиск работал**. «Tag по сервису» — недостаточно; через год search «database» вернёт 40 постмортемов, никто не будет читать все. Хорошая схема: service + failure category (data loss / unavailability / degraded / security / config drift) + contributing factor categories (deployment / config / capacity / dependency / human / monitoring gap) + severity. По этим осям ищется «постмортемы про data loss из config drift на сервисе X за последние 2 года» — три PR'ов, не сорок.
+
+- **L3** — Знает, где живёт postmortem database команды; умеет искать прошлые постмортемы по тегам или симптому. Перед написанием нового постмортема проверяет похожие в архиве.
+- **L3** — В каждом новом постмортеме явно ссылается на похожие из архива («это четвёртый раз похожий config drift на сервисе X в этом году») — это превращает single-postmortem в pattern signal.
+- **L4** — Тегирует свой постмортем по командной схеме: service, failure category, contributing factors, severity. Не «забыли тег» — без тега postmortem не находится через год.
+- **L4** — Регулярно (например, monthly) reviews recent postmortems команды и фиксирует recurring failure modes; формулирует pattern-level findings, которые шире одного инцидента.
+- **L5** — Проектирует схему тегирования для команды или функции: какие оси, какая granularity, как evolve со временем. Без явного дизайна tagging schema становится inconsistent через 6 месяцев.
+- **L5** — Проводит quarterly database review: какие categories доминируют, какие contributing factors повторяются, где systemic patterns. Это **input для priorities** на следующий период (где инвестировать в reliability).
+- **L5** — Использует database как источник сценариев для [Game Day / Chaos Drills](/The-Way-of-SRE/leaves/culture/game-day/): прошлые инциденты — лучший материал для тренировки команды.
+- **L6+** — Внедряет cross-team postmortem sharing: систематический обмен постмортемами между командами, чтобы lessons learned распространялись шире одного team boundary.
+- **L6+** — Аргументирует **public postmortems** как стандарт для significant incidents: GitLab / Cloudflare / Stripe модель публикации. Ведёт переговоры с legal / PR в спорных случаях.
+
+## Материалы
+
+### Книги
+
+- Betsy Beyer et al. — **[Site Reliability Engineering](https://sre.google/sre-book/postmortem-culture/)** (O'Reilly, 2016), глава 15. Раздел «Sharing Postmortems Openly» — фундамент distribution practice; Google как пример org с многолетней внутренней базой постмортемов. Конкретики о tagging schema мало, но дисциплина distribution описана.
+- John Allspaw — **[Each Necessary, But Only Jointly Sufficient](https://link.springer.com/article/10.1007/s10111-011-0185-4)** (2012). Не книга про database, но про подход NBJS, который превращает множество постмортемов в data set для извлечения patterns. Cumulative анализ возможен только при NBJS-формулировке contributing factors.
+
+### Статьи и доклады
+
+- **[GitLab Postmortems](https://about.gitlab.com/blog/categories/postmortem/)** — публичный архив постмортемов GitLab. Не просто отдельные документы, а searchable category в blog с tagging. Один из лучших публичных примеров working postmortem database в индустрии. Используется как референс для собственного дизайна.
+- **[Cloudflare Outage Reports](https://blog.cloudflare.com/tag/outage/)** — категория постмортемов Cloudflare. Меньше по объёму, чем GitLab, но более глубокие технические разборы. Полезно как референс глубины анализа.
+- Dan Luu — **[Post-mortems](https://github.com/danluu/post-mortems)** (GitHub). Community-curated index публичных постмортемов от разных компаний. По моим наблюдениям — самый полезный единичный источник для poiska real-world cases по категориям. Используется как input для game day и для training.
+- Will Gallego — **[Each Necessary, But Only Jointly Sufficient — in practice](https://willgallego.com/2018/03/03/incident-anti-patterns-defining-a-stopping-rule/)**. Применение NBJS на реальном инциденте; объясняет, как формулировать contributing factors так, чтобы они были индексируемы в database.
+
+### Инструменты
+
+- **Markdown в git-репозитории с frontmatter** — самый простой и работающий формат. Один постмортем = один файл; frontmatter содержит tags (service, severity, categories, date); поиск через `grep` или GitHub search. По моим наблюдениям, для команды до 30 человек этого достаточно.
+- **[Notion](https://www.notion.so/) / [Confluence](https://www.atlassian.com/software/confluence) database** — структурированная база с полями и фильтрами. Имеет смысл, когда команда уже живёт в этих инструментах и не хочет миграции в git. Главная ловушка — слабая дисциплина tagging, потому что rich-text редактор провоцирует freeform writing.
+- **[Incident.io](https://incident.io/) / [FireHydrant](https://firehydrant.com/) / [Rootly](https://rootly.com/)** — incident-management платформы с встроенным postmortem-tracker'ом и tagging. По моим наблюдениям, оправданы в org от 50+ инженеров, у которых incident ≥ еженедельно. Преимущество — автоматическая связь postmortem ↔ source incident ↔ action items.
+- **Tag schema в git как первый артефакт** — простой markdown-файл `postmortems/tagging.md` с allowed values для каждого поля. Без явной схемы tagging drift'ит через 6 месяцев, и поиск перестаёт работать.
+
+## Best practices
+
+Главный публичный кейс — **GitLab Public Postmortems**. GitLab публикует постмортемы значимых инцидентов с 2017 года (классический database outage 31 января 2017 — отправная точка) и поддерживает их как searchable category в корпоративном blog'е. На момент 2026 года это один из самых длительно живущих публичных архивов постмортемов в индустрии. Ценность не в том, что они идеально написаны (некоторые ранние — нет), а в том, что **они доступны и используются**: статьи цитируют, инженеры читают перед похожими migration'ами, авторы новых постмортемов смотрят на старые как на модель. GitLab показал, что public postmortems — это не «открыть PR-уязвимость», а **главный канал распространения reliability culture** между компаниями.
+
+**Короткие правила:**
+
+- **Database без tagging — это свалка.** Антипаттерн: «postmortems в Confluence папке, поиск по полному тексту». Через год search «database» возвращает 40 страниц, никто не читает. Правильно: явная tagging schema (service, failure category, contributing factor categories, severity), enforced на review.
+- **Quarterly review — обязательная часть практики.** Без regular review database — мусорка, в которой ценные уроки утопают. Правильно — раз в квартал команда читает summary recent postmortems, ищет patterns, формулирует pattern-level findings. Это превращает single-postmortem learning в team-level learning.
+- **Public-by-default для significant incidents.** Антипаттерн: «постмортем — внутренний документ». Команда учится только на своих инцидентах; индустрия учится только на коротких новостях. Правильно — public по умолчанию для significant incidents (customer-facing > X минут, data loss, security); private — обоснованное исключение, не дефолт. Модель GitLab / Cloudflare / Stripe.
+
+Подробнее:
+
+**Recurring failure modes — главное, что находит quarterly review.** Я регулярно вижу команды, в которых одни и те же contributing factors всплывают в постмортемах раз за разом — config drift на конкретном сервисе, migration без rollback plan, timeout в external dependency без circuit breaker. Каждый отдельный постмортем закрывает action items, но **pattern-level fix** (например, рефакторинг config management для этого сервиса) не делается, потому что никто не смотрит на 6 постмортемов вместе. Postmortem database с tagging — единственный механизм, которым этот pattern становится виден. Без неё команда обречена «удивляться» одной и той же поломке несколько раз в год.
+
+**Постмортем как input для game day.** Я считаю, что лучший источник сценариев [Game Day / Chaos Drills](/The-Way-of-SRE/leaves/culture/game-day/) — это собственные прошлые постмортемы. Реальный сценарий, реальная команда, реальные runbook'и — gap'ы найдены, надо проверить, что они закрыты. Это превращает postmortem database из архивного документа в **активный resource**, и команда чаще к нему возвращается. По моим наблюдениям, команды, которые используют постмортемы для game day, имеют более активные database (читают, тегают, обновляют), чем команды, которые этого не делают.
+
+**Tag schema эволюционирует, но не chaos'ом.** На старте достаточно 3-4 категорий тегов; через год — добавятся новые, увидите паттерны. Эволюция — это нормально, но **chaos** — нет: если каждый инженер придумывает свои тэги, через полгода schema разваливается. Правило: tag schema — отдельный документ в репо, изменения через PR-review. На каждый запрос «добавить новый tag» — обсуждение, нужна ли категория или это синоним существующей. Без этого через год имеете «db-incident», «database-incident», «db-failure», «database-failure» как разные теги.
+
+**Cross-team sharing — следующий шаг после внутренней database.** Команда А научилась — это победа single-team. Команды B и C продолжают наступать на те же грабли — это потеря org-level. Простой механизм cross-team sharing, который я наблюдаю работающим: monthly «postmortem digest» — короткий internal newsletter с TL;DR последних значимых постмортемов всех команд + ссылки. 15 минут чтения в месяц — окупаются одной предотвращённой репликой проблемы в другой команде. Без этого канала каждая команда заново учится тому же.
+
+## Связанные листья
+
+- **[Postmortem Culture](/The-Way-of-SRE/leaves/culture/postmortem-culture/)** — норма разбора (как мы говорим про ошибки); этот лист — система хранения и извлечения уроков из того, что норма уже произвела. Без культуры database заполняется поверхностными «root cause: human error» документами.
+- **[Blameless Postmortem](/The-Way-of-SRE/leaves/practices/blameless-postmortem/)** — процедура разбора, которая порождает документы для database; качество шаблона определяет качество таггирования.
+- **[Action Items Tracking](/The-Way-of-SRE/leaves/practices/action-items-tracking/)** — postmortem без AIs — незаконченный документ; database связывает postmortem ↔ AIs и помогает увидеть, какие action items систематически не закрываются.
+- **[Runbooks](/The-Way-of-SRE/leaves/culture/runbooks/)** — каждый постмортем должен порождать обновление runbook; database — место, где можно найти, какой runbook был открыт в каком инциденте.
+- **[Playbooks](/The-Way-of-SRE/leaves/culture/playbooks/)** — playbook updates — частый артефакт постмортема; pattern-level findings в database часто приводят к новым decision points в playbook.
+- **[Game Day / Chaos Drills](/The-Way-of-SRE/leaves/culture/game-day/)** — постмортемы из database — главный источник сценариев game day; реальные инциденты лучше любых вымышленных.
+- **[Communities of Practice](/The-Way-of-SRE/leaves/culture/communities-of-practice/)** — CoP по reliability — естественное место cross-team sharing постмортемов; monthly digest часто живёт в CoP.
+- **[Incident Response](/The-Way-of-SRE/leaves/practices/incident-response/)** — incident-management платформы автоматически связывают incident ↔ postmortem ↔ database; tooling-side этой практики.
+
+## Открытые вопросы
+
+- **Pattern detection automation** — AI-ассистент, который читает все постмортемы и предлагает patterns (recurring contributing factors, services with repeated issues, action items, которые систематически не закрываются). На начало 2026 года активная область (incident.io AI Postmortem, FireHydrant Signals), но рабочих кейсов в публичной литературе пока мало.
+- **Public-by-default policy в B2B SaaS** — Cloudflare/GitLab/Stripe доказали, что public postmortems совместимы с trust и retention. Я не уверен, как корректно применять policy в B2B SaaS с регулированными industries (финтех, healthtech), где customer SLA содержит NDA на incident details. Если есть рабочая модель — расскажите PR'ом.
+- **Срок хранения и архивирование** — постмортем 2018 года про сервис, который мы уже отписали — нужен ли? Я не нашёл публичной литературы по этому вопросу. Скорее всего, lifecycle policy (retain forever / archive after X years / delete after retired service) — отдельная подтема, которую каждая команда решает по-своему.

--- a/src/content/docs/leaves/culture/runbooks.md
+++ b/src/content/docs/leaves/culture/runbooks.md
@@ -70,8 +70,7 @@ description: Инструкции по реагированию на инцид�
 - **[Postmortem Culture](/The-Way-of-SRE/leaves/culture/postmortem-culture/)** — каждый постмортем порождает обновление runbook (новый или правки существующего); без обновления lesson learned не закреплён.
 - **[Dev Team Partnership](/The-Way-of-SRE/leaves/culture/dev-team-partnership/)** — co-ownership: runbook'и пишутся совместно с product-командой; иначе SRE дежурит вслепую по чужому сервису.
 - **[Toil Automation](/The-Way-of-SRE/leaves/engineering/toil-automation/)** — automatable runbook steps мигрируют в automation; «runbook говорит сделать X — пусть делает скрипт» как естественный следующий шаг.
+- **[Playbooks](/The-Way-of-SRE/leaves/culture/playbooks/)** — runbook отвечает «как делать», playbook — «что решать и кого звать». Runbook'и встраиваются в playbook'и как ссылки на конкретные шаги; разделение явное.
 
 ## Открытые вопросы
-
-- Граница между «runbook» и «playbook» — терминологический разнобой. Google SRE Workbook использует «playbook», DevOps-индустрия чаще «runbook»; некоторые команды разделяют («playbook» = высокоуровневый сценарий, «runbook» = конкретные команды). В этом листе — единый термин «runbook»; обсуждение разделения — на следующей итерации.
 - Я не знаю хорошего ответа на «когда runbook превращается в automated remediation». В тривиальных случаях — alert + 3-step runbook → Lambda или k8s operator. В нетривиальных — runbook содержит ветвление по контексту, и автоматизация рискует выстрелить в ногу при первом edge-case. Граница «можно автоматизировать» / «надо оставить человеческое решение» в публичной литературе чёткой не вижу. Если есть опыт — расскажите PR'ом.

--- a/src/content/docs/leaves/practices/blameless-postmortem.md
+++ b/src/content/docs/leaves/practices/blameless-postmortem.md
@@ -70,6 +70,7 @@ description: Ритуал разбора инцидента — timeline на ф
 - **[SLO / Budget Review](/The-Way-of-SRE/leaves/culture/slo-budget-review/)** — постмортемы выявляют источники бюджет-сжигания; ревью — точка, где lessons learned превращаются в приоритеты.
 - **[Service Ownership](/The-Way-of-SRE/leaves/culture/service-ownership/)** — owner сервиса — accountable person за постмортем и его action items.
 - **[Action Items Tracking](/The-Way-of-SRE/leaves/practices/action-items-tracking/)** — соседняя практика: постмортем генерирует AIs, action items tracking — про их выполнение. Без обоих cycle разорван.
+- **[Postmortem Database](/The-Way-of-SRE/leaves/culture/postmortem-database/)** — куда отправляется готовый постмортем; tagging schema определяет, найдётся ли документ через год; pattern review поверх database — точка превращения single-incident learning в team-level.
 
 ## Открытые вопросы
 

--- a/src/content/docs/leaves/practices/incident-response.md
+++ b/src/content/docs/leaves/practices/incident-response.md
@@ -79,6 +79,8 @@ description: Координация реагирования на инциден
 - **[ChatOps](/The-Way-of-SRE/leaves/engineering/chatops/)** — современные incident-инструменты (incident.io, Netflix Dispatch, FireHydrant) — Slack-native ChatOps; declare / coordinate / sitrep живут в chat с встроенным audit trail.
 - **[Status Page Management](/The-Way-of-SRE/leaves/practices/status-page-management/)** — public status page update — часть IC checklist в моменте инцидента.
 - **[Game Day / Chaos Drills](/The-Way-of-SRE/leaves/culture/game-day/)** — регулярная тренировка этого процесса до того, как он понадобится; разница в MTTR между командами с game day и без — 2–3 раза.
+- **[Playbooks](/The-Way-of-SRE/leaves/culture/playbooks/)** — главный артефакт incident response practice; коэффициент использования playbook'ов в моменте — прямой индикатор зрелости IR.
+- **[Postmortem Database](/The-Way-of-SRE/leaves/culture/postmortem-database/)** — incident-management платформы автоматически связывают incident ↔ postmortem ↔ database; tooling-side этой пары практик.
 
 ## Открытые вопросы
 

--- a/src/data/roadmap.ts
+++ b/src/data/roadmap.ts
@@ -135,6 +135,18 @@ export const roadmap: Roadmap = {
               href: '/leaves/culture/runbooks/',
               priority: 'must',
             },
+            {
+              id: 'playbooks',
+              label: 'Playbooks',
+              href: '/leaves/culture/playbooks/',
+              priority: 'mandatory',
+            },
+            {
+              id: 'postmortem-database',
+              label: 'Postmortem Database',
+              href: '/leaves/culture/postmortem-database/',
+              priority: 'mandatory',
+            },
           ],
         },
         {


### PR DESCRIPTION
## Summary

Batch из двух листьев, раскрывающих L1 `Knowledge Management` с 1 до 3 листьев. Оба закрывают пробелы, на которые явно указывали соседние листья:

- **Playbooks** — закрывает TBD «граница между runbook и playbook» из [runbooks.md](https://github.com/jtprogru/The-Way-of-SRE/blob/main/src/content/docs/leaves/culture/runbooks.md). Чёткое различение по incident-response сообществу 2020-х: runbook = «как делать» для одного симптома; playbook = «что решать и кого звать» для класса инцидентов.
- **Postmortem Database** — закрывает пробел «архив есть, никто не пользуется». Граница с Postmortem Culture: тот лист — норма разбора; этот — система хранения и pattern-level review.

## Изменения

- `src/content/docs/leaves/culture/playbooks.md` — новый лист (Mandatory, SFIA 3–6). Lead — против терминологического разнобоя. Public-кейс — PagerDuty Incident Response (open-source playbook). Ключевые акценты: severity-зависимые playbook'и, decision points как отличие от runbook, playbook без training работает один раз.
- `src/content/docs/leaves/culture/postmortem-database.md` — новый лист (Mandatory, SFIA 3–6). Lead — Confluence-папка ≠ database. Public-кейс — GitLab Public Postmortems. Ключевые акценты: tagging schema, quarterly pattern review, recurring failure modes, cross-team sharing, public-by-default.
- `src/data/roadmap.ts` + `astro.config.mjs` — регистрация под `knowledge-management` L1.
- `README.md` — счётчик Culture 11 → 13.
- `src/content/docs/glossary.mdx` — новый термин `playbook` (с явной границей от runbook); запись `postmortem` теперь линкует на Postmortem Database.
- Cross-refs: back-links в `runbooks.md` (TBD закрыт), `postmortem-culture.md`, `game-day.md`, `blameless-postmortem.md`, `incident-response.md`.

## Эффект

- **Culture теперь 13 листьев** (Knowledge Management 1 → 3). Состояние: 59 листьев (13/23/23).
- **Глоссарий 70 → 71 запись** (+ обновлена postmortem-запись).
- **Снят 1 TBD-маркер** (runbook/playbook border в runbooks.md).
- L1 Knowledge Management больше не в категории «один лист, не раскрыта».

## Test plan

- [x] `npm run build` — без ошибок, 69 страниц.
- [ ] Визуально проверить отображение в sidebar и на карте.
- [ ] Проверить cross-link'и между Playbooks ↔ Runbooks и Postmortem Database ↔ Postmortem Culture / Blameless Postmortem.