### PR TITLE
refactor: облегчить главную сайта и README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,23 +29,11 @@
 
 ## Карта компетенций
 
-Узлы на схеме **кликабельны** — клик по ветви ведёт к её L1-карте на сайте. Полная интерактивная карта с листьями (конкретные умения, материалы, best practices) — <https://jtprogru.github.io/The-Way-of-SRE/>.
-
-```mermaid
-graph LR
-    SRE{SRE}
-    SRE --> SRECulture[SRE Culture]
-    SRE --> SREEngineering[SRE Engineering]
-    SRE --> SREPractices[SRE Practices]
-
-    click SRECulture "https://jtprogru.github.io/The-Way-of-SRE/sre-culture/" "Перейти к SRE Culture"
-    click SREEngineering "https://jtprogru.github.io/The-Way-of-SRE/sre-engineering/" "Перейти к SRE Engineering"
-    click SREPractices "https://jtprogru.github.io/The-Way-of-SRE/sre-practices/" "Перейти к SRE Practices"
-```
+Полная интерактивная карта с листьями (конкретные умения, материалы, best practices) живёт на сайте: <https://jtprogru.github.io/The-Way-of-SRE/>. Карта делится на три ветви:
 
 - **[SRE Culture](https://jtprogru.github.io/The-Way-of-SRE/sre-culture/)** — нормы, отношения, обмен опытом. Главный объект — люди и нормы. **15 листьев** на полной глубине.
-- **[SRE Engineering](https://jtprogru.github.io/The-Way-of-SRE/sre-engineering/)** — технические компетенции и стек. Главный объект — системы. **23 листа** на полной глубине.
-- **[SRE Practices](https://jtprogru.github.io/The-Way-of-SRE/sre-practices/)** — операционные процессы и ритуалы. Главный объект — процесс. **23 листа** на полной глубине.
+- **[SRE Engineering](https://jtprogru.github.io/The-Way-of-SRE/sre-engineering/)** — технические компетенции и стек. Главный объект — системы. **26 листьев** на полной глубине.
+- **[SRE Practices](https://jtprogru.github.io/The-Way-of-SRE/sre-practices/)** — операционные процессы и ритуалы. Главный объект — процесс. **25 листьев** на полной глубине.
 
 Принцип разделения ветвей, политика контроля детализации, оси priority и SFIA — в [Методологии](https://jtprogru.github.io/The-Way-of-SRE/methodology/).
 

--- a/src/components/Spider.astro
+++ b/src/components/Spider.astro
@@ -4,10 +4,12 @@
 // Архитектура: DOM-grid, без SVG/edges. Раньше был горизонтальный
 // SVG-«паучок» с 4 колонками (root → branch → L1 → leaf) и нарисованными
 // рёбрами; на мобильном требовал горизонтального скролла. Сейчас:
-//   - root заголовок сверху по центру
-//   - под ним CSS-grid 3×1fr: одна колонка на каждую ветку
+//   - сверху toolbar (свернуть всё / только обязательное)
+//   - CSS-grid 3×1fr: одна колонка на каждую ветку
 //   - в колонке: branch-header → стек L1-карточек, под L1 — leaves чипами
 //   - точки приоритета на L1, toggle «только обязательное» гасит nice/ondemand
+// Root-bubble «SRE» убран: H1 страницы и tagline уже задают контекст,
+// заметная pill-плашка лишь перегружала верх главной.
 //
 // Цветовая палитра ветвей (amber/teal/indigo) сохранена из старого SVG —
 // единая семантика «ветвь = цвет» используется и в BranchView.astro.
@@ -52,10 +54,6 @@ const isSingle = branches.length === 1;
         <span>Только обязательное</span>
       </label>
     </div>
-  )}
-
-  {!compact && (
-    <div class="board-root" aria-label="Корень карты">{roadmap.root}</div>
   )}
 
   <div class="board" data-priority-filter="off" data-single={isSingle ? 'true' : 'false'}>
@@ -253,20 +251,6 @@ const isSingle = branches.length === 1;
   .board-collapse-all:focus-visible {
     background: var(--sl-color-gray-6);
     border-color: var(--sl-color-gray-4);
-  }
-
-  .board-root {
-    background: var(--sl-color-accent);
-    color: var(--sl-color-white);
-    font-weight: 800;
-    font-size: 1.5rem;
-    letter-spacing: 0.06em;
-    text-align: center;
-    padding: 0.65rem 1.5rem;
-    border-radius: 999px;
-    width: max-content;
-    margin: 0 auto 1.25rem;
-    box-shadow: 0 6px 24px -10px var(--sl-color-accent);
   }
 
   /* 3 колонки на широком, 1 — на узком; никакого горизонтального скролла */

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -3,23 +3,9 @@ title: The Way of SRE
 description: Карта компетенций для развития в роли Site Reliability Engineer
 template: splash
 hero:
-  tagline: Карта направлений в SRE — три ветви, 20 компетенций верхнего уровня, листья с конкретными умениями, материалами и best practices.
-  actions:
-    - text: Roadmap по приоритетам
-      link: /The-Way-of-SRE/priorities/
-      icon: right-arrow
-      variant: primary
-    - text: Чат в Telegram
-      link: https://t.me/jtprogru_chat
-      icon: external
-      variant: secondary
-    - text: GitHub
-      link: https://github.com/jtprogru/The-Way-of-SRE
-      icon: external
-      variant: minimal
+  tagline: Карта направлений в SRE — три ветви, 22 компетенции верхнего уровня, листья с конкретными умениями, материалами и best practices.
 ---
 
-import { LinkButton } from '@astrojs/starlight/components';
 import Spider from '../../components/Spider.astro';
 import { roadmap } from '../../data/roadmap.ts';
 
@@ -37,6 +23,11 @@ export const totalL1 = roadmap.branches.reduce((sum, b) => sum + b.l1.length, 0)
   external references и SFIA-уровнями для самооценки.
   Глубже — <a href={`${base}/about/`}>Мотивация</a>, <a href={`${base}/format/`}>Формат проекта</a>, <a href={`${base}/methodology/`}>Методология</a> и <a href={`${base}/glossary/`}>Глоссарий</a>.
 </div>
+
+<p class="intro-cta">
+  <a href={`${base}/priorities/`}>Roadmap по приоритетам <span aria-hidden="true">→</span></a>
+  <span class="intro-cta-hint">какие компетенции качать в первую очередь</span>
+</p>
 
 <ul class="branches-strip">
   <li data-branch="culture">
@@ -66,7 +57,7 @@ export const totalL1 = roadmap.branches.reduce((sum, b) => sum + b.l1.length, 0)
 <Spider />
 
 <section class="home-section">
-  ## Цель проекта
+  ## О проекте
 
   <div class="section-lede">
     Карта собирает единое видение развития SRE-компетенций в русскоязычном
@@ -80,52 +71,10 @@ export const totalL1 = roadmap.branches.reduce((sum, b) => sum + b.l1.length, 0)
     серебряная пуля. Сверяйте с контекстом своей команды, индустрии и текущей
     зрелости систем.
   </div>
-</section>
-
-<section class="home-section">
-  ## Как читать карту
-
-  <dl class="terms">
-    <div>
-      <dt>Ветвь</dt>
-      <dd>Главный объект деятельности: <strong>Culture</strong> — люди и нормы,
-        <strong>Engineering</strong> — технические артефакты, <strong>Practices</strong> — процессы и ритуалы.</dd>
-    </div>
-    <div>
-      <dt>L1-компетенция</dt>
-      <dd>Верхнеуровневое умение внутри ветви: «Observability», «Incident Management»,
-        «Knowledge Management». На карте всего около {totalL1}.</dd>
-    </div>
-    <div>
-      <dt>Лист</dt>
-      <dd>Конкретная практика внутри L1 со своей страницей: «SLI-based Alerting»,
-        «Blameless Postmortem», «Career Ladders». В каждом — умения, best practices
-        с антипаттернами, инструменты, SFIA-уровни для самооценки.</dd>
-    </div>
-    <div>
-      <dt>Цвет L1</dt>
-      <dd>Приоритет для роли: 🔴 Must Have, 🟡 Mandatory, 🟢 Nice to have, 🔵 On Demand.
-        Подробнее — на странице <a href={`${base}/priorities/`}>Roadmap по приоритетам</a>.</dd>
-    </div>
-  </dl>
-</section>
-
-<section class="home-section">
-  ## Обсудить и контрибутить
 
   <div class="section-lede">
-    Проект открытый. Что куда писать — зависит от формата:
-  </div>
-
-  <div class="cta-row">
-    <LinkButton href="https://t.me/jtprogru_chat" variant="primary" icon="external">
-      Чат — обсудить, задать вопрос
-    </LinkButton>
-    <LinkButton href="https://github.com/jtprogru/The-Way-of-SRE" variant="secondary" icon="external">
-      GitHub — PR, issues
-    </LinkButton>
-    <LinkButton href="https://t.me/jtprogru_channel" variant="minimal" icon="external">
-      Канал — новые листья, анонсы
-    </LinkButton>
+    Проект открытый: правки и новые листья — через <a href="https://github.com/jtprogru/The-Way-of-SRE/pulls" rel="noopener">pull requests</a>,
+    вопросы и предложения — в <a href="https://github.com/jtprogru/The-Way-of-SRE/issues" rel="noopener">issues</a>.
+    Чат, канал и остальные соцссылки — в подвале страницы.
   </div>
 </section>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -19,7 +19,7 @@ hero:
       variant: minimal
 ---
 
-import { CardGrid, LinkCard, LinkButton } from '@astrojs/starlight/components';
+import { LinkButton } from '@astrojs/starlight/components';
 import Spider from '../../components/Spider.astro';
 import { roadmap } from '../../data/roadmap.ts';
 
@@ -38,23 +38,20 @@ export const totalL1 = roadmap.branches.reduce((sum, b) => sum + b.l1.length, 0)
   Глубже — <a href={`${base}/about/`}>Мотивация</a>, <a href={`${base}/format/`}>Формат проекта</a>, <a href={`${base}/methodology/`}>Методология</a> и <a href={`${base}/glossary/`}>Глоссарий</a>.
 </div>
 
-<CardGrid>
-  <LinkCard
-    title="SRE Culture"
-    description="Люди, нормы, обмен опытом. Партнёрство с командами, постмортем-культура, метрики надёжности как инструмент разговора."
-    href={`${base}/sre-culture/`}
-  />
-  <LinkCard
-    title="SRE Engineering"
-    description="Технические компетенции. Observability, SLO, networking, IaC, capacity planning, database reliability."
-    href={`${base}/sre-engineering/`}
-  />
-  <LinkCard
-    title="SRE Practices"
-    description="Процессы и ритуалы. Incident management, change management, on-call, security, профессиональное развитие."
-    href={`${base}/sre-practices/`}
-  />
-</CardGrid>
+<ul class="branches-strip">
+  <li data-branch="culture">
+    <a href={`${base}/sre-culture/`}>SRE Culture</a>
+    <span>Люди, нормы, постмортем-культура.</span>
+  </li>
+  <li data-branch="engineering">
+    <a href={`${base}/sre-engineering/`}>SRE Engineering</a>
+    <span>Observability, SLO, IaC, базы данных.</span>
+  </li>
+  <li data-branch="practices">
+    <a href={`${base}/sre-practices/`}>SRE Practices</a>
+    <span>Incident, change, on-call, security.</span>
+  </li>
+</ul>
 
 <p class="meta-strip">
   <span><strong>3</strong> ветви</span>

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -108,35 +108,77 @@ body:has(.hero) {
 }
 
 /*
- * Pillar-карточки на главной — тонируем в палитру их ветки.
- * Согласованность с Spider: Culture amber, Engineering teal, Practices indigo.
- * Цвет проявляется как левый borderr и переход на hover.
+ * Branches-strip — компактная замена CardGrid+LinkCard для трёх ветвей.
+ * Цель: не съедать пол-экрана большими карточками, но сохранить цветовой
+ * якорь (amber/teal/indigo), общий с Spider и L1-страницами.
  */
-.sl-link-card:has(a[href*='/sre-culture']) {
-  border-inline-start: 4px solid #d97706;
-}
-.sl-link-card:has(a[href*='/sre-engineering']) {
-  border-inline-start: 4px solid #0d9488;
-}
-.sl-link-card:has(a[href*='/sre-practices']) {
-  border-inline-start: 4px solid #6366f1;
+.branches-strip {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+  margin: 1.25rem 0 1.75rem;
+  padding: 0;
+  list-style: none;
 }
 
-:root[data-theme='dark'] .sl-link-card:has(a[href*='/sre-culture']) {
+.branches-strip > li {
+  margin: 0;
+  padding: 0.6rem 0.9rem;
+  border: 1px solid var(--sl-color-gray-5);
+  border-inline-start-width: 4px;
+  border-radius: 0.4rem;
+  background: var(--sl-color-gray-7);
+  transition: transform 0.15s ease, border-color 0.15s ease;
+}
+
+.branches-strip > li:hover {
+  transform: translateY(-1px);
+}
+
+.branches-strip a {
+  display: block;
+  font-weight: 600;
+  font-size: 0.98rem;
+  text-decoration: none;
+  color: var(--sl-color-white);
+}
+
+:root[data-theme='light'] .branches-strip a {
+  color: var(--sl-color-text);
+}
+
+.branches-strip span {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: var(--sl-color-gray-3);
+}
+
+.branches-strip > li[data-branch='culture'] {
+  border-inline-start-color: #d97706;
+}
+.branches-strip > li[data-branch='engineering'] {
+  border-inline-start-color: #0d9488;
+}
+.branches-strip > li[data-branch='practices'] {
+  border-inline-start-color: #6366f1;
+}
+
+:root[data-theme='dark'] .branches-strip > li[data-branch='culture'] {
   border-inline-start-color: #f59e0b;
 }
-:root[data-theme='dark'] .sl-link-card:has(a[href*='/sre-engineering']) {
+:root[data-theme='dark'] .branches-strip > li[data-branch='engineering'] {
   border-inline-start-color: #2dd4bf;
 }
-:root[data-theme='dark'] .sl-link-card:has(a[href*='/sre-practices']) {
+:root[data-theme='dark'] .branches-strip > li[data-branch='practices'] {
   border-inline-start-color: #818cf8;
 }
 
-.sl-link-card:has(a[href*='/sre-culture']):hover,
-.sl-link-card:has(a[href*='/sre-engineering']):hover,
-.sl-link-card:has(a[href*='/sre-practices']):hover {
-  transform: translateY(-2px);
-  transition: transform 0.15s ease;
+@media (max-width: 50rem) {
+  .branches-strip {
+    grid-template-columns: 1fr;
+  }
 }
 
 /*

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -50,10 +50,12 @@ body:has(.hero) {
   grid-template-columns: 100% !important;
   max-width: none !important;
   /*
-   * Starlight даёт hero на ≥50rem `padding-block: clamp(2.5rem, ..., 10rem)`
-   * — снизу на широких экранах до 160px пустоты между CTA и следующим блоком.
-   * Урезаем bottom; top оставляем по Starlight для дыхания между navbar и title.
+   * Starlight даёт hero на ≥50rem `padding-block: clamp(2.5rem, calc(1rem + 6vw), 10rem)`
+   * — снизу до 160px пустоты под CTA, сверху столько же между navbar и H1.
+   * Урезаем оба: bottom — фиксированно 2rem, top — clamp с шагом ~85% от
+   * starlight-дефолта, чтобы навигация дышала, но не отрывалась от title.
    */
+  padding-top: clamp(2rem, calc(0.85rem + 5.1vw), 8.5rem) !important;
   padding-bottom: 2rem !important;
 }
 
@@ -79,6 +81,46 @@ body:has(.hero) {
 
 .intro-blurb > p {
   margin: 0;
+}
+
+/*
+ * Intro-CTA — компактный «куда дальше» под intro-blurb. Раньше эта роль
+ * принадлежала primary-LinkButton в hero, но один одинокий button в hero у
+ * Starlight выглядит несоразмерно; текстовая стрелка-ссылка с подсказкой
+ * лучше масштабируется и не дублирует branches-strip.
+ */
+.intro-cta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: baseline;
+  gap: 0.4rem 0.75rem;
+  margin: -1.25rem 0 2rem;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.intro-cta a {
+  font-weight: 600;
+  color: var(--sl-color-accent-high);
+  text-decoration: none;
+  border-bottom: 1px dashed var(--sl-color-accent);
+}
+
+.intro-cta a:hover,
+.intro-cta a:focus-visible {
+  color: var(--sl-color-white);
+  border-bottom-style: solid;
+}
+
+:root[data-theme='light'] .intro-cta a:hover,
+:root[data-theme='light'] .intro-cta a:focus-visible {
+  color: var(--sl-color-text);
+}
+
+.intro-cta-hint {
+  color: var(--sl-color-gray-3);
+  font-size: 0.92rem;
 }
 
 /* Meta-strip: счётчики и open source метка */
@@ -218,54 +260,3 @@ body:has(.hero) {
   margin: 0;
 }
 
-/*
- * Глоссарий «Как читать карту»: dl, разбитый на пары через
- * обёртку <div>, чтобы grid лёг по парам термин/определение.
- */
-.terms {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1.25rem;
-  text-align: left;
-  margin: 1rem 0 0;
-}
-
-.terms > div {
-  display: grid;
-  grid-template-columns: minmax(8rem, 12rem) 1fr;
-  gap: 1rem;
-  align-items: baseline;
-}
-
-.terms dt {
-  font-weight: 700;
-  color: var(--sl-color-white);
-  font-size: 0.95rem;
-}
-
-:root[data-theme='light'] .terms dt {
-  color: var(--sl-color-text);
-}
-
-.terms dd {
-  margin: 0;
-  color: var(--sl-color-gray-2);
-  font-size: 0.95rem;
-  line-height: 1.6;
-}
-
-@media (max-width: 640px) {
-  .terms > div {
-    grid-template-columns: 1fr;
-    gap: 0.25rem;
-  }
-}
-
-/* CTA-row: три LinkButton'а в горизонтальный ряд с переносом на узком */
-.cta-row {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.75rem;
-  margin-top: 1.5rem;
-}

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -65,6 +65,17 @@ body:has(.hero) {
 }
 
 /*
+ * Центрируем H1 + tagline. Starlight задаёт .copy как flex-column с
+ * align-items: flex-start (вариант с image справа). У нас одна колонка
+ * и нет image — без override H1/tagline прижимаются влево к расширенной
+ * области и выглядят оторванно от branches-strip ниже.
+ */
+.hero .copy {
+  align-items: center !important;
+  text-align: center;
+}
+
+/*
  * Intro-blurb на главной — короткий «зачем это нужно» между hero и карточками.
  * Используем <div> вместо <p>, потому что MDX внутри prose-обёртки автоматически
  * оборачивает текст в <p>, и nested-p в HTML невалиден.


### PR DESCRIPTION
## Summary

- **README**: убрал mermaid-схему (дублировала маркдаун-список ниже без новой информации) и поправил устаревшие счётчики листьев — Engineering 23 → 26, Practices 23 → 25.
- **Главная сайта**: заменил `CardGrid` с тремя большими `LinkCard` на компактный `<ul class=\"branches-strip\">`. Три узких блока в ряд (на мобильном — в столбик), цветовой якорь amber/teal/indigo сохранён через тонкий `border-inline-start`, согласован со Spider. Описания ветвей сжаты до одной фразы.
- **CSS**: вместо точечных правил `.sl-link-card:has(...)` — отдельный блок `.branches-strip` с per-branch цветами через `data-branch`.

## Test plan

- [ ] `task dev` — главная: три ветви видны компактным рядом, цветной borderr слева совпадает со Spider.
- [ ] Мобильная ширина (<50rem): strip перестраивается в столбик.
- [ ] README рендерится на GitHub без артефактов mermaid; счётчики совпадают с фактическим числом файлов в `src/content/docs/leaves/*/`.
- [ ] Светлая и тёмная темы — текст и цветной borderr читаются.