### PR TITLE
feat(footer): показывать SHA коммита, из которого собран сайт

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,6 +6,7 @@
 // Не рендерится на splash-страницах (Starlight их полностью кастомизирует);
 // для главной site-footer добавлен inline в src/content/docs/index.mdx.
 
+import { execSync } from 'node:child_process';
 import EditLink from 'virtual:starlight/components/EditLink';
 import LastUpdated from 'virtual:starlight/components/LastUpdated';
 import Pagination from 'virtual:starlight/components/Pagination';
@@ -14,6 +15,21 @@ import { findLeafContext, priorityLabels } from '../data/roadmap.ts';
 
 const year = new Date().getFullYear();
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+// Commit, из которого собран сайт. В CI берём GITHUB_SHA (надёжно
+// при shallow checkout), локально — git rev-parse. Без ссылки —
+// просто маркер сборки в подвале.
+const commitSha = (() => {
+  const envSha = process.env.GITHUB_SHA;
+  if (envSha) return envSha.slice(0, 7);
+  try {
+    return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+  } catch {
+    return null;
+  }
+})();
 
 /*
  * Leaf-context: на страницах /leaves/{branch}/{slug}/ показываем над
@@ -118,6 +134,12 @@ const socials = [
       <a href="https://github.com/jtprogru/The-Way-of-SRE/blob/main/LICENSE" rel="noopener">Apache-2.0</a>
       <span aria-hidden="true">·</span>
       <span>open source</span>
+      {commitSha && (
+        <>
+          <span aria-hidden="true">·</span>
+          <span class="site-footer-build" title="Commit, из которого собран сайт">сборка <code>{commitSha}</code></span>
+        </>
+      )}
     </div>
   </div>
 </footer>
@@ -358,5 +380,12 @@ const socials = [
   }
   .site-footer-meta > span[aria-hidden='true'] {
     opacity: 0.5;
+  }
+  .site-footer-build code {
+    font-family: var(--sl-font-mono, ui-monospace, SFMono-Regular, monospace);
+    font-size: 0.95em;
+    background: none;
+    padding: 0;
+    color: inherit;
   }
 </style>


### PR DESCRIPTION
## Summary

- В подвал сайта (`Footer.astro`, блок `site-footer-meta`) добавлен маркер «сборка `<sha>`» — без ссылки, с тултипом «Commit, из которого собран сайт».
- SHA читается на этапе билда: приоритет — `process.env.GITHUB_SHA` (надёжно при shallow checkout в GH Actions), fallback — `git rev-parse --short HEAD`. Если ни то ни другое не доступно, блок не рендерится.
- Код моноширинный, без фона/паддинга, чтобы вписаться в визуальный ритм остальной мета-строки (`© … · Apache-2.0 · open source · сборка abcdef0`).

## Зачем

Чтобы быстро понимать, какая ревизия сейчас задеплоена на GitHub Pages, не сравнивая визуально содержимое сайта с историей репо. Полезно при отладке деплоя и при проверке «доехал ли мой PR».

## Test plan

- [x] `npm run build` локально — без ошибок, маркер присутствует в `dist/index.html`.
- [ ] После мержа: проверить, что на проде https://jtprogru.github.io/The-Way-of-SRE/ в подвале появилась «сборка <sha>», и она совпадает с верхушкой `main`.
- [ ] Проверить на нескольких страницах (главная, leaf, sre-culture) — маркер один и тот же.
- [ ] Тёмная и светлая темы — `code` читается, не выбивается из строки.