### PR TITLE
fix(docs): человеко-читаемый текст ссылки на страницу приоритетов

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 ## Roadmap
 
-Последовательность развития компетенций и приоритеты (Must Have / Mandatory / Nice to have / On Demand) — на странице [/priorities/](https://jtprogru.github.io/The-Way-of-SRE/priorities/) сайта; определения осей — в [Методологии](https://jtprogru.github.io/The-Way-of-SRE/methodology/).
+Последовательность развития компетенций и приоритеты (Must Have / Mandatory / Nice to have / On Demand) — на странице [Приоритеты](https://jtprogru.github.io/The-Way-of-SRE/priorities/) сайта; определения осей — в [Методологии](https://jtprogru.github.io/The-Way-of-SRE/methodology/).
 
 Изначальный план новых листьев (10 шт) закрыт; следующая фаза — листья из open-questions / TBD-маркеров уже существующих.
 

--- a/src/content/docs/about.mdx
+++ b/src/content/docs/about.mdx
@@ -12,7 +12,7 @@ description: Зачем существует The Way of SRE и для кого
 ## О работе
 
 - **SRE MindMap** — карта всех возможных и рекомендованных к развитию ветвей.
-- **SRE Roadmap** — инкрементальное приращение экспертизы и предполагаемый путь развития (см. [/priorities/](/The-Way-of-SRE/priorities/) и [Методологию](/The-Way-of-SRE/methodology/)).
+- **SRE Roadmap** — инкрементальное приращение экспертизы и предполагаемый путь развития (см. [Приоритеты](/The-Way-of-SRE/priorities/) и [Методологию](/The-Way-of-SRE/methodology/)).
 
 ## Дисклеймер
 

--- a/src/content/docs/methodology.mdx
+++ b/src/content/docs/methodology.mdx
@@ -75,7 +75,7 @@ description: Методологический каркас The Way of SRE — п
 - 🟢 **Nice to have** — расширяет возможности, но не блокирует.
 - 🔵 **On Demand** — изучается, когда проект требует.
 
-Priority L1 живут только в `src/data/roadmap.ts` (поле `priority`). Цветовая разметка на странице [/priorities/](/The-Way-of-SRE/priorities/) генерируется из этого поля автоматически.
+Priority L1 живут только в `src/data/roadmap.ts` (поле `priority`). Цветовая разметка на странице [Приоритеты](/The-Way-of-SRE/priorities/) генерируется из этого поля автоматически.
 
 ### SFIA — уровень зрелости инженера
 


### PR DESCRIPTION
## Summary
- Заменил текст ссылки `/priorities/` (сырой URL-путь) на «Приоритеты» в `README.md`, `src/content/docs/about.mdx`, `src/content/docs/methodology.mdx`.
- Рядом с соседним «Методологию» / «Методологии» путь-как-текст выглядел как опечатка; теперь обе ссылки в одинаковом регистре.
- URL не меняется, только подпись ссылки.

## Test plan
- [ ] `pnpm dev` — открыть `/about/`, `/methodology/`, проверить README на GitHub: ссылка отображается как «Приоритеты», ведёт на `/priorities/`.