### PR TITLE
ci: проверять сборку сайта на pull request

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,44 @@
+name: Build check
+
+# Проверка сборки на PR: тот же `astro build`, что и на деплое, но без публикации.
+# Ловит поломки зависимостей и контента до попадания в main.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'astro.config.mjs'
+      - 'tsconfig.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/build-check.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Новый пуш в PR отменяет предыдущую проверку
+concurrency:
+  group: build-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Astro site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Деплой-workflow (`deploy-site.yml`) триггерится только по `push` в `main`, других workflow в репозитории нет. Из-за этого любой PR — включая мажорные бампы зависимостей от dependabot — вливается без проверки, и первый `astro build` на новых зависимостях случается уже на деплое.

Добавлен `build-check.yml`: та же связка `npm ci` + `npm run build` на Node 22, что и в деплое, но без шагов upload-pages-artifact и deploy-pages. Триггер `pull_request` с тем же списком путей, `permissions: contents: read`, concurrency отменяет предыдущий прогон при новом пуше в ветку.

Проверено локально на текущем main (уже с sharp 0.35.0 из #99): сборка проходит, 77 страниц.