### PR TITLE
ci: обновить actions до версий на Node 24

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -33,10 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'
@@ -48,7 +48,7 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
@@ -62,4 +62,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Прогон [30206452507](https://github.com/jtprogru/The-Way-of-SRE/actions/runs/30206452507) прошёл зелёным, но повесил две deprecation-аннотации: раннер форсирует Node 24 для actions, собранных под Node 20.

Подняты мажоры, у которых в `action.yml` уже `runs.using: node24`:

| action | было | стало |
| --- | --- | --- |
| `actions/checkout` | v4 | v7 |
| `actions/setup-node` | v4 | v7 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |

`upload-artifact` из второй аннотации напрямую не используется — он приходит внутрь `upload-pages-artifact`, и в v5 это уже `upload-artifact@v7`.

Ломающие изменения по пути проверил, на проект не влияют: `setup-node@v6` сузил автокеширование до npm (у нас `cache: 'npm'` задан явно), `checkout@v7` запретил checkout форк-PR для `pull_request_target` и `workflow_run` (оба триггера не используются), `checkout@v5` поднял минимальную версию раннера (на ubuntu-latest неактуально).

Задеты оба workflow. Проверка сборки на этом PR гоняет уже новые версии.