### PR TITLE
nav: единый источник состава doc-nav и соцссылок

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,8 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 
-import { buildRoadmapSidebar } from './src/data/sidebar';
+import { buildReferenceGroup, buildRoadmapSidebar, buildTopLevelDocNav } from './src/data/sidebar';
+import { socials } from './src/data/nav';
 
 // Production config: The Way of SRE roadmap site.
 // Деплой автоматический через .github/workflows/deploy-site.yml на push в main.
@@ -16,45 +17,17 @@ export default defineConfig({
       locales: {
         root: { label: 'Русский', lang: 'ru' },
       },
-      social: [
-        {
-          icon: 'github',
-          label: 'GitHub',
-          href: 'https://github.com/jtprogru/The-Way-of-SRE',
-        },
-        {
-          icon: 'telegram',
-          label: 'Telegram канал',
-          href: 'https://t.me/jtprogru_channel',
-        },
-        {
-          icon: 'comment-alt',
-          label: 'Telegram чат',
-          href: 'https://t.me/jtprogru_chat',
-        },
-        {
-          icon: 'external',
-          label: 'Блог jtprog.ru',
-          href: 'https://jtprog.ru/',
-        },
-      ],
+      // Соцссылки в шапке; тот же массив рендерит подвал (Footer.astro).
+      social: socials,
+      // Состав сайдбара целиком из данных: мета-страницы — src/data/nav.ts,
+      // ветви, L1 и листья — src/data/roadmap.ts. Перечислять их здесь
+      // руками не нужно, форму дерева задаёт src/data/sidebar.ts.
       sidebar: [
         { label: 'Карта компетенций', link: '/' },
         { label: 'Roadmap (приоритеты)', link: '/priorities/' },
-        { label: 'Порядок построения', link: '/reliability-hierarchy/' },
-        // Ветви, L1 и листья строятся из src/data/roadmap.ts —
-        // руками их здесь перечислять не нужно, см. src/data/sidebar.ts.
+        ...buildTopLevelDocNav(),
         ...buildRoadmapSidebar(),
-        {
-          label: 'Справочник',
-          collapsed: true,
-          items: [
-            { label: 'Глоссарий', link: '/glossary/' },
-            { label: 'Методология', link: '/methodology/' },
-            { label: 'Формат проекта', link: '/format/' },
-            { label: 'Мотивация', link: '/about/' },
-          ],
-        },
+        buildReferenceGroup(),
       ],
       customCss: ['./src/styles/custom.css'],
       components: {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,10 +1,11 @@
 ---
 // Кастомный Footer:
 // 1) сохраняет дефолтное поведение Starlight (EditLink + LastUpdated + Pagination)
-// 2) добавляет site-wide блок снизу: соцссылки, копирайт, лицензия.
+// 2) добавляет site-wide блок снизу: doc-nav, соцссылки, копирайт, лицензия.
 //
-// Не рендерится на splash-страницах (Starlight их полностью кастомизирует);
-// для главной site-footer добавлен inline в src/content/docs/index.mdx.
+// Рендерится и на splash-страницах тоже, включая главную: EditLink,
+// LastUpdated и Pagination там пустые, а site-footer выводится как обычно.
+// Дублировать его инлайном в index.mdx не нужно.
 
 import { execSync } from 'node:child_process';
 import EditLink from 'virtual:starlight/components/EditLink';
@@ -12,6 +13,7 @@ import LastUpdated from 'virtual:starlight/components/LastUpdated';
 import Pagination from 'virtual:starlight/components/Pagination';
 import { Icon } from '@astrojs/starlight/components';
 import { findLeafContext, priorityLabels } from '../data/roadmap.ts';
+import { navFor, socials } from '../data/nav.ts';
 
 const year = new Date().getFullYear();
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
@@ -43,20 +45,9 @@ const localPath = Astro.url.pathname.startsWith(base)
 const leafMatch = localPath.match(/^\/leaves\/([^/]+)\/([^/]+)\/?$/);
 const leafCtx = leafMatch ? findLeafContext(leafMatch[1], leafMatch[2]) : null;
 
-const docNav = [
-  { label: 'Мотивация', href: `${base}/about/` },
-  { label: 'Формат', href: `${base}/format/` },
-  { label: 'Методология', href: `${base}/methodology/` },
-  { label: 'Порядок построения', href: `${base}/reliability-hierarchy/` },
-  { label: 'Глоссарий', href: `${base}/glossary/` },
-] as const;
-
-const socials = [
-  { icon: 'github', label: 'GitHub', href: 'https://github.com/jtprogru/The-Way-of-SRE' },
-  { icon: 'telegram', label: 'Telegram канал', href: 'https://t.me/jtprogru_channel' },
-  { icon: 'comment-alt', label: 'Telegram чат', href: 'https://t.me/jtprogru_chat' },
-  { icon: 'external', label: 'Блог jtprog.ru', href: 'https://jtprog.ru/' },
-] as const;
+// Состав doc-nav и соцссылок — в src/data/nav.ts. В подвале места хватает,
+// поэтому здесь полные подписи и на одну страницу больше, чем в шапке.
+const docNav = navFor('footer');
 ---
 
 <footer class="sl-flex">
@@ -118,7 +109,7 @@ const socials = [
       {docNav.map((d, i) => (
         <>
           {i > 0 && <span aria-hidden="true">·</span>}
-          <a href={d.href}>{d.label}</a>
+          <a href={`${base}${d.href}`}>{d.label}</a>
         </>
       ))}
     </nav>

--- a/src/components/SocialIcons.astro
+++ b/src/components/SocialIcons.astro
@@ -1,23 +1,21 @@
 ---
 // Override Starlight SocialIcons:
-// перед стандартными соцссылками ставим doc-nav (О проекте / Формат / Методология),
-// чтобы новые страницы были видны в шапке на каждой странице.
+// перед стандартными соцссылками ставим doc-nav, чтобы мета-страницы были
+// видны в шапке на каждой странице. Состав — в src/data/nav.ts (слот 'header').
 
 import Default from '@astrojs/starlight/components/SocialIcons.astro';
+import { navFor, navLabel } from '../data/nav.ts';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
-const docNav = [
-  { label: 'Мотивация', href: `${base}/about/` },
-  { label: 'Формат', href: `${base}/format/` },
-  { label: 'Методология', href: `${base}/methodology/` },
-  { label: 'Глоссарий', href: `${base}/glossary/` },
-] as const;
+// Состав и подписи — из src/data/nav.ts. В шапке места мало, поэтому
+// здесь короткие подписи (navLabel) и не все мета-страницы.
+const docNav = navFor('header');
 ---
 
 <nav class="header-docnav" aria-label="Документы проекта">
   {docNav.map((d) => (
-    <a href={d.href}>{d.label}</a>
+    <a href={`${base}${d.href}`}>{navLabel(d, 'header')}</a>
   ))}
 </nav>
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -8,8 +8,11 @@ hero:
 
 import Spider from '../../components/Spider.astro';
 import { roadmap } from '../../data/roadmap.ts';
+import { navFor } from '../../data/nav.ts';
 
 export const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+// Строка «Глубже — …» остаётся прозой, но состав ссылок берётся из nav.ts.
+export const introNav = navFor('intro');
 export const totalLeaves = roadmap.branches.reduce(
   (sum, b) => sum + b.l1.reduce((s, l1) => s + (l1.leaves?.length ?? 0), 0),
   0,
@@ -21,7 +24,12 @@ export const totalL1 = roadmap.branches.reduce((sum, b) => sum + b.l1.length, 0)
   процессов. Эта карта показывает, что входит в роль и в какой последовательности
   разумно развиваться. Каждый лист — отдельная практика с материалами,
   external references и SFIA-уровнями для самооценки.
-  Глубже — <a href={`${base}/about/`}>Мотивация</a>, <a href={`${base}/format/`}>Формат проекта</a>, <a href={`${base}/methodology/`}>Методология</a> и <a href={`${base}/glossary/`}>Глоссарий</a>.
+  Глубже — {introNav.map((e, i) => (
+    <>
+      {i > 0 && (i === introNav.length - 1 ? ' и ' : ', ')}
+      <a href={`${base}${e.href}`}>{e.label}</a>
+    </>
+  ))}.
 </div>
 
 <p class="intro-cta">

--- a/src/data/nav.ts
+++ b/src/data/nav.ts
@@ -1,0 +1,125 @@
+// Единственный источник состава doc-nav (мета-страницы) и соцссылок.
+//
+// До этого файла список мета-страниц был продублирован в четырёх местах —
+// astro.config.mjs, SocialIcons.astro, Footer.astro, index.mdx — и нигде не
+// совпадал полностью. Ровно так «Порядок построения» и не доехал до шапки
+// и до главной.
+//
+// Списки в шапке, подвале, сайдбаре и на главной по-прежнему различаются:
+// в шапке меньше места, поэтому там короткие подписи и нет «Порядка
+// построения». Задача файла — не схлопнуть эти различия, а объявить их в
+// одном месте: поле `in` говорит, где страница показывается.
+//
+// href хранится БЕЗ base-префикса: astro.config.mjs подставляет базу сам,
+// компоненты добавляют её через import.meta.env.BASE_URL. Иначе на GitHub
+// Pages получится /The-Way-of-SRE/The-Way-of-SRE/about/.
+//
+// Структура графа (ветви, L1, листья) живёт в roadmap.ts, дерево сайдбара
+// собирается в sidebar.ts — здесь только мета-страницы и внешние ссылки.
+
+import type { StarlightIcon } from '@astrojs/starlight/types';
+
+/**
+ * Места, где показывается мета-страница:
+ *   sidebar — левый сайдбар,
+ *   header  — doc-nav в шапке (мало места, короткие подписи),
+ *   footer  — doc-nav в подвале,
+ *   intro   — строка «Глубже — …» на главной.
+ */
+export type NavSlot = 'sidebar' | 'header' | 'footer' | 'intro';
+
+export interface NavEntry {
+  id: string;
+  /** Полная подпись: сайдбар, подвал, главная. */
+  label: string;
+  /** Компактная подпись для шапки; если не задана — берётся label. */
+  shortLabel?: string;
+  /** Путь без base-префикса. */
+  href: string;
+  in: NavSlot[];
+  /**
+   * В сайдбаре страница живёт на верхнем уровне, а не в группе «Справочник».
+   * Это про позицию, а не про принадлежность: `in` всё равно содержит
+   * 'sidebar'.
+   */
+  topLevel?: boolean;
+}
+
+/**
+ * Порядок здесь — общий для всех мест. Добавление новой мета-страницы:
+ * одна запись, и она сама появляется везде, где перечислено в `in`.
+ */
+export const docNav: NavEntry[] = [
+  {
+    id: 'about',
+    label: 'Мотивация',
+    href: '/about/',
+    in: ['sidebar', 'header', 'footer', 'intro'],
+  },
+  {
+    id: 'format',
+    label: 'Формат проекта',
+    shortLabel: 'Формат',
+    href: '/format/',
+    in: ['sidebar', 'header', 'footer', 'intro'],
+  },
+  {
+    id: 'methodology',
+    label: 'Методология',
+    href: '/methodology/',
+    in: ['sidebar', 'header', 'footer', 'intro'],
+  },
+  {
+    id: 'reliability-hierarchy',
+    label: 'Порядок построения',
+    href: '/reliability-hierarchy/',
+    in: ['sidebar', 'footer'],
+    topLevel: true,
+  },
+  {
+    id: 'glossary',
+    label: 'Глоссарий',
+    href: '/glossary/',
+    in: ['sidebar', 'header', 'footer', 'intro'],
+  },
+];
+
+export interface SocialEntry {
+  icon: StarlightIcon;
+  label: string;
+  href: string;
+}
+
+/** Внешние ссылки: шапка (через Starlight) и подвал (через Footer.astro). */
+export const socials: SocialEntry[] = [
+  {
+    icon: 'github',
+    label: 'GitHub',
+    href: 'https://github.com/jtprogru/The-Way-of-SRE',
+  },
+  {
+    icon: 'telegram',
+    label: 'Telegram канал',
+    href: 'https://t.me/jtprogru_channel',
+  },
+  {
+    icon: 'comment-alt',
+    label: 'Telegram чат',
+    href: 'https://t.me/jtprogru_chat',
+  },
+  {
+    icon: 'external',
+    label: 'Блог jtprog.ru',
+    href: 'https://jtprog.ru/',
+  },
+];
+
+/** Мета-страницы для конкретного места, в общем порядке docNav. */
+export function navFor(slot: NavSlot): NavEntry[] {
+  return docNav.filter((e) => e.in.includes(slot));
+}
+
+/** Подпись с учётом места: в шапке — короткая, если она задана. */
+export function navLabel(entry: NavEntry, slot: NavSlot): string {
+  return slot === 'header' ? (entry.shortLabel ?? entry.label) : entry.label;
+}

--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -8,6 +8,7 @@
 // нового листа требует правки ТОЛЬКО roadmap.ts.
 
 import { roadmap, type Branch } from './roadmap';
+import { navFor } from './nav';
 
 export interface SidebarLink {
   label: string;
@@ -55,4 +56,25 @@ export function buildBranchSidebar(branch: Branch): SidebarGroup {
  */
 export function buildRoadmapSidebar(): SidebarGroup[] {
   return roadmap.branches.map(buildBranchSidebar);
+}
+
+/**
+ * Мета-страницы, которые в сайдбаре живут на верхнем уровне,
+ * а не внутри группы «Справочник».
+ */
+export function buildTopLevelDocNav(): SidebarLink[] {
+  return navFor('sidebar')
+    .filter((e) => e.topLevel)
+    .map((e) => ({ label: e.label, link: e.href }));
+}
+
+/** Группа «Справочник» — остальные мета-страницы из nav.ts. */
+export function buildReferenceGroup(): SidebarGroup {
+  return {
+    label: 'Справочник',
+    collapsed: true,
+    items: navFor('sidebar')
+      .filter((e) => !e.topLevel)
+      .map((e) => ({ label: e.label, link: e.href })),
+  };
 }


### PR DESCRIPTION
Закрывает #107. Продолжение эпика #103 после #108.

## Что сделано

`src/data/nav.ts` — единственное место, где перечислены мета-страницы и соцссылки. Поле `in` говорит, где страница показывается (`sidebar` / `header` / `footer` / `intro`), `shortLabel` даёт компактную подпись для шапки, где места меньше. Различия между четырьмя местами никуда не делись, но теперь они объявлены, а не разъезжаются по файлам.

Потребители перестали держать свои копии:

- `astro.config.mjs` — `social: socials`, «Порядок построения» и группа «Справочник» через `buildTopLevelDocNav()` / `buildReferenceGroup()`;
- `SocialIcons.astro` — `navFor('header')` + `navLabel()`;
- `Footer.astro` — `navFor('footer')` и тот же массив `socials`;
- `index.mdx` — строка «Глубже — …» осталась прозой, но состав ссылок берётся из слота `intro`.

Форму дерева сайдбара по-прежнему задаёт `sidebar.ts` — туда добавились две функции, чтобы конфиг не собирал группы сам.

## Проверено на собранном `dist/`

Главный критерий проверил эмпирически, а не на глаз: временно добавил в `nav.ts` одну запись со всеми четырьмя слотами и пересобрал. Она появилась в группе «Справочник», в шапке (короткой подписью), в подвале и в строке на главной. Запись откачена.

Дальше — состав каждого места после рефакторинга:

- шапка: Мотивация, Формат, Методология, Глоссарий — как было;
- подвал: Мотивация, Формат проекта, Методология, Порядок построения, Глоссарий;
- сайдбар: 7 пунктов верхнего уровня, «Справочник» из 4 страниц, 67 листьев на месте, цепочка до текущей страницы раскрывается;
- главная: разметка строки «Глубже — …» побайтово совпала с прежней.

Base-префикс отработал верно: в `dist/` все ссылки вида `/The-Way-of-SRE/about/`, задвоения базы нет. `npm run build` — 78 страниц без предупреждений, `npm run lint` — 0 issues.

## Два изменения, которые видно глазами

Это чистый рефакторинг по составу, но две мелочи в оформлении поменялись намеренно, ровно про них issue и говорил.

Порядок внутри «Справочника» стал общим с шапкой и подвалом: Мотивация, Формат проекта, Методология, Глоссарий. Раньше в сайдбаре он был обратным — это моё решение из #108, и оно расходилось с остальными местами.

В подвале «Формат» стал «Формат проекта». Короткая подпись теперь живёт только там, где на неё есть причина, — в шапке.

## Заодно

Комментарий в шапке `Footer.astro` утверждал, что на splash-страницах футер не рендерится, а на главной `site-footer` вставлен инлайном в `index.mdx`. Проверил по собранной странице: подвал на главной рисует сам компонент, никакой инлайновой разметки в `index.mdx` нет. Комментарий поправлен.

## Дальше

Остался #105 — hub-страницы L1 и breadcrumbs. Там есть открытый вопрос про URL новых страниц, его надо решить до реализации.
