### PR TITLE
chore(deps): обновить markdownlint-cli2 до 0.23.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4620,9 +4620,9 @@
       }
     },
     "node_modules/globby": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.1.tgz",
-      "integrity": "sha512-JmsqJalahxxgW8V2ecSQ2G7UjPlI9cpKdrkG9KoNiXhd/YslXOTEB0cViENWUznuovIuNT+FkMbraDGjr4FCUg==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.2.tgz",
+      "integrity": "sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5794,14 +5794,14 @@
       }
     },
     "node_modules/markdownlint-cli2": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.23.1.tgz",
-      "integrity": "sha512-20JPI5W+HpV1OA+pUM712wgvL4GzYNUvbmhLU8KlEYJ1kCDx4soZ4/Xqd+WkLrPTOKMAn8SfO3zYFrK8GLlwQg==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.23.2.tgz",
+      "integrity": "sha512-eUhcnkSpzURo/o4htSqc7LPDszgOOTknhU4eY/sPHvMCLxnTCYscv1gw1/js/idmaZPisv9ECVEIORcllqjTUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "globby": "16.2.1",
-        "js-yaml": "5.2.1",
+        "globby": "16.2.2",
+        "js-yaml": "5.2.2",
         "jsonc-parser": "3.3.1",
         "jsonpointer": "5.0.1",
         "markdown-it": "14.3.0",
@@ -5834,9 +5834,9 @@
       }
     },
     "node_modules/markdownlint-cli2/node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Закрывает Dependabot alert #15 — [GHSA-pm4m-ph32-ghv5](https://github.com/advisories/GHSA-pm4m-ph32-ghv5), js-yaml 5.2.1, CVSS 7.5: экспоненциальное время парсинга вложенных flow-коллекций, документ под 200 байт вешает event loop на минуты.

js-yaml нет в наших зависимостях напрямую — он приходит от `markdownlint-cli2`, который пинит его точной версией (`"js-yaml": "5.2.1"`), поэтому ни `npm audit fix`, ни Dependabot поднять его самостоятельно не могли. В `markdownlint-cli2@0.23.2` пин уже на пропатченный `5.2.2`.

Диапазон в `package.json` (`^0.23.1`) остаётся прежним, меняется только `package-lock.json`:

| пакет | было | стало |
|---|---|---|
| markdownlint-cli2 | 0.23.1 | 0.23.2 |
| js-yaml (транзитивно) | 5.2.1 | 5.2.2 |
| globby (транзитивно) | 16.2.1 | 16.2.2 |

Проверено: `npm run lint` — 0 issues, `npm audit` — 0 vulnerabilities.

Практический риск от самой уязвимости был низкий: dev-зависимость, линтер гоняется в CI по собственным `.md`, недоверенного ввода не парсит.