### PR TITLE
Add Telemetry Economics to Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  <img src="./logo/sre.svg" alt="The Way of SRE — карта компетенций: ветви Culture (15 листьев), Engineering (27), Practices (25)" width="900">
+  <img src="./logo/sre.svg" alt="The Way of SRE — карта компетенций: ветви Culture (15 листьев), Engineering (28), Practices (25)" width="900">
 </p>
 
 > Вдохновлен проектом [The-Way-of-DevOps](https://github.com/evgeniy-kharchenko/The-Way-of-DevOps) за авторством [Евгения Харченко](https://github.com/evgeniy-kharchenko).
@@ -32,7 +32,7 @@
 Полная интерактивная карта с листьями (конкретные умения, материалы, best practices) живёт на сайте: <https://jtprogru.github.io/The-Way-of-SRE/>. Карта делится на три ветви:
 
 - **[SRE Culture](https://jtprogru.github.io/The-Way-of-SRE/sre-culture/)** — нормы, отношения, обмен опытом. Главный объект — люди и нормы. **15 листьев** на полной глубине.
-- **[SRE Engineering](https://jtprogru.github.io/The-Way-of-SRE/sre-engineering/)** — технические компетенции и стек. Главный объект — системы. **27 листьев** на полной глубине.
+- **[SRE Engineering](https://jtprogru.github.io/The-Way-of-SRE/sre-engineering/)** — технические компетенции и стек. Главный объект — системы. **28 листьев** на полной глубине.
 - **[SRE Practices](https://jtprogru.github.io/The-Way-of-SRE/sre-practices/)** — операционные процессы и ритуалы. Главный объект — процесс. **25 листьев** на полной глубине.
 
 Всё дерево целиком, от корня до подлистов, — на странице [Mind map](https://jtprogru.github.io/The-Way-of-SRE/mindmap/): двусторонняя карта с зумом, фильтром по приоритету и сворачиванием веток.

--- a/src/content/docs/glossary.mdx
+++ b/src/content/docs/glossary.mdx
@@ -98,6 +98,12 @@ Architecture Decision Record — фиксация технического ре�
 
 *Категория C* — двойная форма «карьерная лестница (career ladder)» при первом упоминании. См. [`Career Ladders`](/The-Way-of-SRE/leaves/culture/career-ladders/). Источник: Will Larson, *Staff Engineer*; [Progression.fyi](https://progression.fyi/) (75+ публичных ladders).
 
+### cardinality
+
+Число уникальных комбинаций значений измерений. В модели Prometheus каждая уникальная комбинация label образует отдельный временной ряд; labels с неограниченным множеством значений (`user_id`, email, request ID) могут резко увеличить объём данных.
+
+*Категория A* — «кардинальность (cardinality)» при первом упоминании. См. [`Telemetry Economics`](/The-Way-of-SRE/leaves/engineering/telemetry-economics/). Источник: [Prometheus — Metric and label naming](https://prometheus.io/docs/practices/naming/).
+
 ### change failure rate
 
 Доля изменений в production, которые приводят к degraded service: rollback, hotfix или customer-facing incident. Одна из четырёх [DORA](#dora)-метрик. Считается из связи `deploy ↔ incident`; требует явного определения «failure» на команду, чтобы цифры разных команд были сопоставимы.
@@ -445,6 +451,12 @@ Software Bill of Materials — список всех dependencies артефак
 Software Composition Analysis — анализ сторонних dependencies артефакта на known CVE; опирается на [`SBOM`](#sbom). Отличается от [`SAST`](#sast) объектом: SAST смотрит свой код, SCA — чужой. Инструменты — govulncheck, Snyk, Dependabot, Trivy.
 
 *Категория A*. См. [`Vulnerability Management`](/The-Way-of-SRE/leaves/practices/vulnerability-management/), [`Security Code Review`](/The-Way-of-SRE/leaves/practices/security-code-review/), [`Supply Chain Security`](/The-Way-of-SRE/leaves/practices/supply-chain-security/).
+
+### sampling
+
+Выбор подмножества telemetry для обработки или хранения. Head sampling принимает решение в начале trace и не видит его целиком; tail sampling учитывает завершённый или почти завершённый trace, но требует state и сложнее масштабируется.
+
+*Категория A* — «сэмплирование (sampling)» при первом упоминании. См. [`Telemetry Economics`](/The-Way-of-SRE/leaves/engineering/telemetry-economics/). Источник: [OpenTelemetry — Sampling](https://opentelemetry.io/docs/concepts/sampling/).
 
 ### service mesh
 

--- a/src/content/docs/leaves/engineering/cost-management.md
+++ b/src/content/docs/leaves/engineering/cost-management.md
@@ -87,6 +87,7 @@ description: SRE-практика управления стоимостью об
 - **[Service Ownership](/The-Way-of-SRE/leaves/culture/service-ownership/)** — каталог сервиса содержит cost-метаданные: owner, budget, current spend, trend.
 - **[Stakeholder Management](/The-Way-of-SRE/leaves/culture/stakeholder-management/)** — cost-translation для finance — отдельный навык внутри stakeholder management; conversation с CFO требует unit economics, не engineering-метрик.
 - **[Cloud Providers](/The-Way-of-SRE/leaves/engineering/cloud-providers/)** — биллинговая модель провайдера — fundamental input в FinOps lifecycle; managed-сервисы vs self-hosted — central cost-trade-off.
+- **[Telemetry Economics](/The-Way-of-SRE/leaves/engineering/telemetry-economics/)** — применение unit economics к metrics, logs и traces: ingest, cardinality, sampling, retention и стоимость pipeline.
 
 ## Открытые вопросы
 

--- a/src/content/docs/leaves/engineering/telemetry-economics.md
+++ b/src/content/docs/leaves/engineering/telemetry-economics.md
@@ -1,0 +1,90 @@
+---
+title: Telemetry Economics
+description: Управление ценностью и стоимостью метрик, логов и трейсов через cardinality, sampling, retention и бюджеты сигналов
+---
+
+:::note[Метаданные листа]
+- **Ветвь:** Engineering
+- **Путь:** Observability / Telemetry Economics
+- **SFIA-уровни:** 3, 4, 5, 6
+- **Приоритет:** Mandatory
+- **Статус:** draft
+:::
+
+В документации Prometheus есть короткое предупреждение, которое я считаю одним из самых дорогих для игнорирования: каждая уникальная комбинация label создаёт новый временной ряд, поэтому `user_id` и email нельзя использовать как неограниченные значения label. Проблема начинается с одной строки инструментации, а проявляется уже в storage, запросах и счёте за observability.
+
+**Telemetry Economics** — инженерная дисциплина управления полезностью и полной стоимостью метрик, логов и трейсов: объём приёма, [cardinality](/The-Way-of-SRE/glossary/#cardinality), индексация, [sampling](/The-Way-of-SRE/glossary/#sampling), retention, вычисления, egress и время сопровождения. Это не общий [Cost Management](/The-Way-of-SRE/leaves/engineering/cost-management/): здесь единица решения — сигнал и путь telemetry от SDK до backend. И это не разрешение удалять данные вслепую ради экономии — после изменения команда должна проверить, что сохранила диагностику известных failure modes.
+
+## Что должен уметь
+
+Главный навык на уровне L5 — связать каждый крупный класс telemetry с потребителем, сроком хранения и измеримой стоимостью, а затем уменьшить объём без потери критичных сценариев расследования. Самая опасная оптимизация здесь — та, у которой есть экономия, но нет проверки диагностической ценности.
+
+**L3**
+- Оценивает суточный входящий объём по формуле `events/s × average bytes/event × 86 400` и отдельно помечает, что compression, replication и indexing изменят итоговую стоимость хранения.
+- Находит неограниченные labels и attributes (`user_id`, email, request ID) и объясняет, почему их место — в логах или трейсах, а не в labels метрик.
+- Читает usage и billing по сигналам: metrics, logs, traces; называет крупнейшие источники объёма для своего сервиса.
+
+**L4**
+- Задаёт бюджет сигнала для сервиса: допустимый ingest, cardinality, retention и владелец; настраивает уведомление о выходе за бюджет.
+- Применяет фильтрацию, агрегацию, relabeling и разные сроки хранения по классам данных; документирует, что удаляется и зачем.
+- Выбирает head sampling или tail sampling для трейсов, фиксирует правило и проверяет сохранение ошибок, высокой задержки и редких бизнес-критичных путей.
+- Сравнивает объём и качество диагностики до и после изменения на одинаковом окне нагрузки.
+
+**L5**
+- Проектирует путь telemetry через OpenTelemetry Collector или эквивалентный слой: limits, backpressure, batching, routing, sampling и наблюдаемость самого pipeline.
+- Вводит квоты и showback по `team / service / environment`, не смешивая production и ephemeral-окружения в одном неразличимом счёте.
+- Сравнивает managed и self-hosted варианты по TCO: compute, storage, replication, egress, лицензии и инженерное сопровождение.
+- Определяет SLO pipeline telemetry: допустимые потери, задержка экспорта и поведение при перегрузке для каждого сигнала.
+
+**L6+**
+- Задаёт организационную политику для cardinality, retention, sampling, PII-redaction и исключений; каждое исключение имеет владельца и срок пересмотра.
+- Связывает расходы с полезностью: стоимость по сервису и сигналу, использование дашбордами и алертами, подтверждённые сценарии расследований.
+- Проектирует переносимость telemetry и exit plan, чтобы смена backend не требовала повторной инструментации всех сервисов.
+
+## Материалы
+
+### Книги
+
+- Charity Majors, Liz Fong-Jones, George Miranda — **[Observability Engineering](https://www.oreilly.com/library/view/observability-engineering/9781492076438/)** (O'Reilly, 2022). Не книга про FinOps, но полезна для оценки диагностической ценности высококонтекстных событий; читать вместе с документацией конкретного pipeline и его billing model.
+
+### Статьи и документация
+
+- Prometheus — **[Metric and label naming](https://prometheus.io/docs/practices/naming/)**. Самый короткий обязательный источник перед проектированием labels: прямо связывает уникальную комбинацию label с новым временным рядом и приводит примеры неограниченной cardinality.
+- OpenTelemetry — **[Sampling](https://opentelemetry.io/docs/concepts/sampling/)**. Хорошая граница применимости: sampling уменьшает стоимость, но добавляет compute, сопровождение и риск потерять критичную информацию; отдельно разобраны head и tail sampling.
+- OpenTelemetry — **[Scaling the Collector](https://opentelemetry.io/docs/collector/scaling/)**. Я бы сверял с ним topology review: stateless processors и stateful tail sampling масштабируются по-разному, а неверное распределение spans может дать неполные traces.
+- OpenTelemetry — **[Collector](https://opentelemetry.io/docs/collector/)**. Vendor-neutral слой приёма, обработки и экспорта telemetry; полезен как точка применения policy до отправки в backend.
+
+### Инструменты
+
+- **OpenTelemetry Collector** — центральный слой для routing, filtering, batching и sampling. Его собственные queue, drop, latency и resource metrics входят в обязательную наблюдаемость pipeline.
+- **Prometheus-compatible TSDB analysis** — отчёты по series и labels помогают найти источники cardinality; конкретная команда зависит от выбранного backend.
+- **Billing / usage export backend** — источник истины для unit cost по сигналу. Если provider не отдаёт usage на уровне service/team, showback придётся строить до экспорта по resource attributes.
+
+## Best practices
+
+Самая простая проверка начинается не с миграции backend, а с таблицы `signal → producer → consumer → retention → daily volume → owner`. Я считаю отсутствие consumer и owner достаточной причиной для review, но не для мгновенного удаления: редкий сигнал может быть нужен только во время аварии, и это проверяется по runbook и прошлым расследованиям.
+
+**Короткие правила:**
+
+- **Budget до optimization.** Без baseline невозможно доказать экономию или заметить, что объём просто переехал из одного сигнала в другой.
+- **Неограниченные идентификаторы не становятся labels метрик.** Request ID и user ID сохраняют контекст в логах или трейсах; в метриках используются ограниченные измерения.
+- **Sampling — policy с тестом, а не процент.** Правило хранится как код, проходит review и проверяется на ошибках, высокой задержке и редких путях.
+
+**Tail sampling не бесплатен.** Он может сохранить traces по итоговому error, latency или attribute, чего не умеет чистый head sampling, но требует state и осторожного масштабирования. Для низкого объёма или требований, запрещающих отбрасывание данных, OpenTelemetry прямо предлагает рассмотреть отказ от sampling.
+
+**Telemetry pipeline — production-сервис.** Если Collector теряет данные при backpressure, проблема observability становится невидимой именно во время перегрузки. Поэтому его capacity, очереди, drops, export errors и latency получают владельца, SLO и проверяемое поведение при отказе backend.
+
+**Сокращение retention не заменяет классификацию.** Я бы отделял короткоживущие debug-данные от audit или incident evidence до выбора сроков. Юридические и договорные требования проверяются с владельцами compliance; универсального retention для всех сигналов нет.
+
+## Связанные листья
+
+- **[Cost Management](/The-Way-of-SRE/leaves/engineering/cost-management/)** — даёт общий FinOps-контур; этот лист уточняет unit economics observability pipeline.
+- **[SLI-based Alerting](/The-Way-of-SRE/leaves/engineering/sli-based-alerting/)** — telemetry, питающую SLI и paging, нельзя удалять без проверки алертов и burn-rate расчёта.
+- **[Alert Fatigue Management](/The-Way-of-SRE/leaves/engineering/alert-fatigue-management/)** — неиспользуемые сигналы и некачественные алерты создают одновременно cognitive и financial waste.
+- **[Capacity Planning](/The-Way-of-SRE/leaves/engineering/capacity-planning/)** — нагрузка pipeline telemetry требует собственного capacity model, особенно для stateful sampling.
+- **[Infrastructure as Code](/The-Way-of-SRE/leaves/engineering/infrastructure-as-code/)** — quotas, retention и sampling policy должны быть reviewable и воспроизводимыми.
+
+## Открытые вопросы
+
+- Как оценивать option value сигнала, который редко запрашивают, но который оказался решающим в одном критическом расследовании?
+- Как единообразно считать стоимость profiles рядом с metrics, logs и traces, пока поддержка профилей в экосистеме ещё развивается?

--- a/src/content/docs/leaves/engineering/telemetry-economics.md
+++ b/src/content/docs/leaves/engineering/telemetry-economics.md
@@ -11,7 +11,7 @@ description: Управление ценностью и стоимостью м�
 - **Статус:** draft
 :::
 
-В документации Prometheus есть короткое предупреждение, которое я считаю одним из самых дорогих для игнорирования: каждая уникальная комбинация label создаёт новый временной ряд, поэтому `user_id` и email нельзя использовать как неограниченные значения label. Проблема начинается с одной строки инструментации, а проявляется уже в storage, запросах и счёте за observability.
+Один label с идентификатором пользователя, добавленный ради удобного дашборда, — самый частый способ вырастить счёт за observability, не меняя нагрузку. Я регулярно вижу этот сюжет в одном и том же порядке: строка проходит review как безобидная, число временных рядов растёт вместе с аудиторией, запросы к TSDB начинают отваливаться по таймауту, и только на этом шаге кто-то открывает billing. В документации Prometheus про это написано прямо: каждая уникальная комбинация label создаёт новый временной ряд, поэтому `user_id` и email не годятся как значения label. Проблема начинается с одной строки инструментации, а проявляется в storage, запросах и деньгах.
 
 **Telemetry Economics** — инженерная дисциплина управления полезностью и полной стоимостью метрик, логов и трейсов: объём приёма, [cardinality](/The-Way-of-SRE/glossary/#cardinality), индексация, [sampling](/The-Way-of-SRE/glossary/#sampling), retention, вычисления, egress и время сопровождения. Это не общий [Cost Management](/The-Way-of-SRE/leaves/engineering/cost-management/): здесь единица решения — сигнал и путь telemetry от SDK до backend. И это не разрешение удалять данные вслепую ради экономии — после изменения команда должна проверить, что сохранила диагностику известных failure modes.
 
@@ -32,7 +32,7 @@ description: Управление ценностью и стоимостью м�
 
 **L5**
 - Проектирует путь telemetry через OpenTelemetry Collector или эквивалентный слой: limits, backpressure, batching, routing, sampling и наблюдаемость самого pipeline.
-- Вводит квоты и showback по `team / service / environment`, не смешивая production и ephemeral-окружения в одном неразличимом счёте.
+- Вводит квоты и showback по `team / service / environment`, не смешивая production и эфемерные окружения в одном неразличимом счёте.
 - Сравнивает managed и self-hosted варианты по TCO: compute, storage, replication, egress, лицензии и инженерное сопровождение.
 - Определяет SLO pipeline telemetry: допустимые потери, задержка экспорта и поведение при перегрузке для каждого сигнала.
 
@@ -51,14 +51,14 @@ description: Управление ценностью и стоимостью м�
 
 - Prometheus — **[Metric and label naming](https://prometheus.io/docs/practices/naming/)**. Самый короткий обязательный источник перед проектированием labels: прямо связывает уникальную комбинацию label с новым временным рядом и приводит примеры неограниченной cardinality.
 - OpenTelemetry — **[Sampling](https://opentelemetry.io/docs/concepts/sampling/)**. Хорошая граница применимости: sampling уменьшает стоимость, но добавляет compute, сопровождение и риск потерять критичную информацию; отдельно разобраны head и tail sampling.
-- OpenTelemetry — **[Scaling the Collector](https://opentelemetry.io/docs/collector/scaling/)**. Я бы сверял с ним topology review: stateless processors и stateful tail sampling масштабируются по-разному, а неверное распределение spans может дать неполные traces.
+- OpenTelemetry — **[Scaling the Collector](https://opentelemetry.io/docs/collector/scaling/)**. По моим наблюдениям, topology review без этой страницы получается неполным: stateless processors и stateful tail sampling масштабируются по-разному, а неверное распределение spans может дать неполные traces.
 - OpenTelemetry — **[Collector](https://opentelemetry.io/docs/collector/)**. Vendor-neutral слой приёма, обработки и экспорта telemetry; полезен как точка применения policy до отправки в backend.
 
 ### Инструменты
 
-- **OpenTelemetry Collector** — центральный слой для routing, filtering, batching и sampling. Его собственные queue, drop, latency и resource metrics входят в обязательную наблюдаемость pipeline.
-- **Prometheus-compatible TSDB analysis** — отчёты по series и labels помогают найти источники cardinality; конкретная команда зависит от выбранного backend.
-- **Billing / usage export backend** — источник истины для unit cost по сигналу. Если provider не отдаёт usage на уровне service/team, showback придётся строить до экспорта по resource attributes.
+- **OpenTelemetry Collector** — центральный слой для routing, filtering, batching и sampling. По моим наблюдениям, к нему приходят не ради vendor neutrality, а когда надоедает менять правила фильтрации в десятке SDK вместо одного места. Его собственные queue, drop, latency и resource metrics входят в обязательную наблюдаемость pipeline.
+- **Отчёты по series и labels на стороне backend** — первый инструмент поиска источников cardinality. Я вижу, что команды чаще обходятся встроенными средствами своего TSDB и берут отдельный анализатор редко: обычно тогда, когда backend такой отчёт не отдаёт вовсе.
+- **Billing / usage export backend** — источник истины для unit cost по сигналу. Я регулярно вижу, что provider не отдаёт usage на уровне service/team; тогда showback приходится строить самому по resource attributes ещё до экспорта.
 
 ## Best practices
 
@@ -74,7 +74,7 @@ description: Управление ценностью и стоимостью м�
 
 **Telemetry pipeline — production-сервис.** Если Collector теряет данные при backpressure, проблема observability становится невидимой именно во время перегрузки. Поэтому его capacity, очереди, drops, export errors и latency получают владельца, SLO и проверяемое поведение при отказе backend.
 
-**Сокращение retention не заменяет классификацию.** Я бы отделял короткоживущие debug-данные от audit или incident evidence до выбора сроков. Юридические и договорные требования проверяются с владельцами compliance; универсального retention для всех сигналов нет.
+**Сокращение retention не заменяет классификацию.** Короткоживущие debug-данные я отделяю от audit и incident evidence до того, как выбирать сроки. Юридические и договорные требования проверяются с владельцами compliance; универсального retention для всех сигналов нет.
 
 ## Связанные листья
 

--- a/src/content/docs/sre-engineering/observability.mdx
+++ b/src/content/docs/sre-engineering/observability.mdx
@@ -5,9 +5,9 @@ description: Метрики, логи и трейсы, dashboards и alerting-с
 
 import NodeCards from '../../../components/NodeCards.astro';
 
-Построение и поддержка систем наблюдаемости: метрики, логи, трейсы (три столпа observability). Включает dashboards, alerting-стратегии и SLI-based мониторинг.
+Построение и поддержка систем наблюдаемости: метрики, логи и трейсы. Включает dashboards, alerting-стратегии, SLI-based мониторинг и управление стоимостью telemetry.
 
-**L2-концепты:** Metrics · Logging · Distributed Tracing · SLI-based Alerting · Symptom vs Cause Alerting · End-User Monitoring
+**L2-концепты:** Metrics · Logging · Distributed Tracing · SLI-based Alerting · Symptom vs Cause Alerting · End-User Monitoring · Telemetry Economics
 
 ## Практики
 

--- a/src/data/roadmap.ts
+++ b/src/data/roadmap.ts
@@ -265,6 +265,12 @@ export const roadmap: Roadmap = {
               href: '/leaves/engineering/alert-fatigue-management/',
               priority: 'mandatory',
             },
+            {
+              id: 'telemetry-economics',
+              label: 'Telemetry Economics',
+              href: '/leaves/engineering/telemetry-economics/',
+              priority: 'mandatory',
+            },
           ],
         },
         {


### PR DESCRIPTION
## Что изменено

- добавлен leaf `Telemetry Economics` с практиками управления cardinality, sampling, retention и unit economics pipeline;
- leaf добавлен в обязательную часть Observability roadmap;
- добавлены термины `cardinality` и `sampling` в glossary;
- добавлены связи с Observability и Cost Management;
- обновлены счётчики leaves в README.

## Зачем

Observability должна учитывать не только полноту сигналов, но и стоимость их получения и хранения. Новый материал показывает, как обсуждать этот компромисс через измеримые параметры, не привязываясь к конкретному vendor.

Основные источники:

- https://prometheus.io/docs/practices/naming/
- https://opentelemetry.io/docs/concepts/sampling/
- https://opentelemetry.io/docs/collector/
- https://opentelemetry.io/docs/collector/scaling/

## Влияние

Только документация. Добавляется один новый leaf; существующие уровни и обязательность других leaves не меняются.

## Проверки

- `astro check`: 0 errors, 0 warnings, 0 hints
- `astro build`: 103 pages built, включая `/leaves/engineering/telemetry-economics/`
- `git diff main...HEAD --check`
