### PR TITLE
docs(readme): вынести ссылки на Telegram-канал и чат в шапку

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@
   <a href="LICENSE">
     <img src="https://img.shields.io/badge/License-Apache--2.0-brightgreen" alt="Apache 2.0 License">
   </a>
+  <a href="https://t.me/+LFsXS2FuZiwwMzky">
+    <img src="https://img.shields.io/badge/Telegram-канал-2CA5E0?logo=telegram&logoColor=white" alt="Telegram-канал проекта">
+  </a>
+  <a href="https://t.me/+BPP6mMOs34s2Yzcy">
+    <img src="https://img.shields.io/badge/Telegram-чат-2CA5E0?logo=telegram&logoColor=white" alt="Telegram-чат проекта">
+  </a>
+</p>
+
+<p align="center">
+  Анонсы новых листьев — в <a href="https://t.me/+LFsXS2FuZiwwMzky">Telegram-канале</a>, обсуждение и вопросы — в <a href="https://t.me/+BPP6mMOs34s2Yzcy">чате</a>.
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Зачем

Ссылки на Telegram-канал и чат были только на сайте — в `format.mdx` и в боковой навигации (`src/data/nav.ts`). Читатель, который открывает репозиторий на GitHub и дальше сайта не идёт, о них не узнавал.

## Что изменилось

- в блок бейджей под заголовком README добавлены два бейджа: `Telegram — канал` и `Telegram — чат`;
- под бейджами — короткая строка-подпись, что где: канал для анонсов новых листьев, чат для обсуждения и вопросов.

Ссылки те же, что уже используются на сайте, менялись только в README.

## Как проверить

- `make check` зелёный локально (оглавление, линт, типы, сборка, стиль-чек 70 листьев);
- в превью README на GitHub бейджи рендерятся и ведут на инвайты канала и чата.

## Риски

Нет: правка только в README, заголовки не трогались, doctoc-оглавление не изменилось.