### PR TITLE
build(deps): держать typescript на 6.x до поддержки в astro check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,15 @@ updates:
       # 5.2.2 и получает свою вложенную копию. Мажорный бамп сломает билд.
       - dependency-name: "js-yaml"
         update-types: ["version-update:semver-major"]
+      # typescript держится на 6.x, пока `astro check` не умеет работать с 7.
+      # Нативный компилятор TypeScript 7 не отдаёт программный API, на котором
+      # построен @astrojs/language-server, и цель typecheck падает целиком:
+      # «The TypeScript module loaded (found 7.0.2) does not expose the
+      # programmatic API that `astro check` relies on». Апстрим ведёт поддержку
+      # в https://github.com/withastro/roadmap/discussions/1321 — как появится,
+      # снять эти две строки.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Зачем

PR #141 (typescript 6.0.3 → 7.0.2) висит красным, и это не поправимо на нашей стороне. Нативный компилятор TypeScript 7 не отдаёт программный API, на котором построен `@astrojs/language-server`, поэтому `astro check` падает и уносит цель `typecheck` целиком:

```
The TypeScript module loaded (found 7.0.2) does not expose the programmatic API
that `astro check` relies on. TypeScript's native compiler (7.0 and later) does
not ship this API yet.
```

Апстрим ведёт поддержку в [withastro/roadmap#1321](https://github.com/withastro/roadmap/discussions/1321).

## Что изменилось

Мажорные бампы `typescript` уходят в `ignore` — тем же приёмом и с тем же форматом комментария, что уже применён к `js-yaml`. Патчи и миноры 6.x продолжают приезжать.

Когда `astro check` научится работать с TS 7, снимаются две строки.

## Что дальше с #141

Закрою его следом со ссылкой сюда.