### PR TITLE
refactor(data): иерархия надёжности ссылается на листья по id

### DIFF
--- a/src/components/ReliabilityPyramid.astro
+++ b/src/components/ReliabilityPyramid.astro
@@ -11,7 +11,7 @@
 //
 // Данные — src/data/reliabilityHierarchy.ts (единственный источник правды).
 
-import { reliabilityHierarchy } from '../data/reliabilityHierarchy.ts';
+import { layerLeaves, reliabilityHierarchy } from '../data/reliabilityHierarchy.ts';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const link = (path: string) => `${base}${path}`;
@@ -88,7 +88,7 @@ function ink(step: string): string {
         <div class="pyramid-body">
           <p class="pyramid-gist">{layer.gist}</p>
           <ul class="pyramid-leaves">
-            {layer.leaves.map((leaf) => (
+            {layerLeaves(layer).map((leaf) => (
               <li>
                 <a class="pyramid-leaf" href={link(leaf.href)}>{leaf.label}</a>
               </li>

--- a/src/data/reliabilityHierarchy.ts
+++ b/src/data/reliabilityHierarchy.ts
@@ -13,13 +13,15 @@
 //   - SFIA-уровень — фронт-маттер листьев
 //   - иерархия надёжности (этот файл) — в каком порядке практики строятся
 //
-// Инвариант: каждый href должен указывать на существующий лист. При удалении
-// или переименовании листа — синхронизировать с src/data/roadmap.ts.
+// Слой называет свои листья одними id. Ни имени, ни адреса файл не хранит:
+// раньше хранил и то и другое, и это было единственное место вне roadmap.ts,
+// где узел карты лежал копией. Переименование листа копию не трогало, а
+// проверять её было нечем — пирамида молча показывала прежнее имя.
+//
+// Инвариант: каждый id существует в roadmap.ts. Неизвестный роняет сборку в
+// layerLeaves(), до неё то же самое ловит `make data-check` внятным текстом.
 
-export interface HierarchyLeafRef {
-  label: string;
-  href: string;
-}
+import { leavesOf, roadmap, type LeafNode } from './roadmap.ts';
 
 export interface HierarchyLayer {
   /** Якорь для ссылок с других страниц. */
@@ -29,7 +31,8 @@ export interface HierarchyLayer {
   label: string;
   /** Одна фраза: что даёт слой и почему без него верхние не работают. */
   gist: string;
-  leaves: HierarchyLeafRef[];
+  /** id листьев из roadmap.ts; имя и адрес берутся оттуда же. */
+  leaves: string[];
 }
 
 /** Слои в порядке снизу вверх: от фундамента к вершине. */
@@ -40,9 +43,9 @@ export const reliabilityHierarchy: HierarchyLayer[] = [
     label: 'Monitoring',
     gist: 'Без измерений всё выше — угадывание: непонятно, сломано ли, насколько и стало ли лучше после починки.',
     leaves: [
-      { label: 'SLO Engineering', href: '/engineering/slo-engineering/' },
-      { label: 'SLI-based Alerting', href: '/engineering/sli-based-alerting/' },
-      { label: 'Symptom vs Cause Alerting', href: '/engineering/symptom-vs-cause-alerting/' },
+      'slo-engineering',
+      'sli-based-alerting',
+      'symptom-vs-cause-alerting',
     ],
   },
   {
@@ -51,9 +54,9 @@ export const reliabilityHierarchy: HierarchyLayer[] = [
     label: 'Incident Response',
     gist: 'Сигнал превращается в действие: кто разбирает, по какой роли, за какое время.',
     leaves: [
-      { label: 'Incident Response', href: '/practices/incident-response/' },
-      { label: 'On-Call Rotation', href: '/practices/on-call-rotation/' },
-      { label: 'Severity Classification', href: '/practices/severity-classification/' },
+      'incident-response',
+      'on-call-rotation',
+      'severity-classification',
     ],
   },
   {
@@ -62,9 +65,9 @@ export const reliabilityHierarchy: HierarchyLayer[] = [
     label: 'Postmortem / Root Cause Analysis',
     gist: 'Инцидент превращается в изменение системы, а не в устный опыт одного дежурного.',
     leaves: [
-      { label: 'Blameless Postmortem', href: '/practices/blameless-postmortem/' },
-      { label: 'Postmortem Culture', href: '/culture/postmortem-culture/' },
-      { label: 'Systematic Troubleshooting', href: '/engineering/systematic-troubleshooting/' },
+      'blameless-postmortem',
+      'postmortem-culture',
+      'systematic-troubleshooting',
     ],
   },
   {
@@ -73,9 +76,9 @@ export const reliabilityHierarchy: HierarchyLayer[] = [
     label: 'Testing + Release procedures',
     gist: 'Самая частая причина инцидентов — изменение; слой ограничивает ущерб от собственных релизов.',
     leaves: [
-      { label: 'Test Strategy', href: '/engineering/test-strategy/' },
-      { label: 'CI/CD', href: '/engineering/ci-cd/' },
-      { label: 'Progressive Delivery', href: '/practices/progressive-delivery/' },
+      'test-strategy',
+      'ci-cd',
+      'progressive-delivery',
     ],
   },
   {
@@ -84,8 +87,8 @@ export const reliabilityHierarchy: HierarchyLayer[] = [
     label: 'Capacity Planning',
     gist: 'Отказ от нехватки ресурсов — предсказуемый и потому предотвратимый класс отказов.',
     leaves: [
-      { label: 'Capacity Planning', href: '/engineering/capacity-planning/' },
-      { label: 'Cost Management', href: '/engineering/cost-management/' },
+      'capacity-planning',
+      'cost-management',
     ],
   },
   {
@@ -94,9 +97,9 @@ export const reliabilityHierarchy: HierarchyLayer[] = [
     label: 'Development',
     gist: 'Надёжность закладывается в архитектуру и код, а не докручивается мониторингом сверху.',
     leaves: [
-      { label: 'Resilience Patterns', href: '/engineering/resilience-patterns/' },
-      { label: 'Infrastructure as Code', href: '/engineering/infrastructure-as-code/' },
-      { label: 'Chaos Engineering', href: '/engineering/chaos-engineering/' },
+      'resilience-patterns',
+      'infrastructure-as-code',
+      'chaos-engineering',
     ],
   },
   {
@@ -105,9 +108,35 @@ export const reliabilityHierarchy: HierarchyLayer[] = [
     label: 'Product',
     gist: 'Требуемый уровень надёжности — продуктовое решение: сколько недоступности переживёт пользователь и бизнес.',
     leaves: [
-      { label: 'Dev Team Partnership', href: '/culture/dev-team-partnership/' },
-      { label: 'Stakeholder Management', href: '/culture/stakeholder-management/' },
-      { label: 'SLO / Budget Review', href: '/culture/slo-budget-review/' },
+      'dev-team-partnership',
+      'stakeholder-management',
+      'slo-budget-review',
     ],
   },
 ];
+
+/** Все листья карты по id. Уникальность id проверяет tools/data/check.ts. */
+const leafById = new Map<string, LeafNode>(
+  roadmap.branches.flatMap((b) =>
+    b.l1.flatMap((l1) => leavesOf(l1).map((leaf): [string, LeafNode] => [leaf.id, leaf])),
+  ),
+);
+
+/**
+ * Листья слоя как узлы карты — с актуальными именем, адресом и приоритетом.
+ *
+ * Неизвестный id роняет сборку, а не пропускает ступень молча: слой без
+ * листьев на странице выглядит осмысленно («практик пока нет»), и опечатка
+ * дожила бы до продакшена.
+ */
+export function layerLeaves(layer: HierarchyLayer): LeafNode[] {
+  return layer.leaves.map((id) => {
+    const leaf = leafById.get(id);
+    if (!leaf) {
+      throw new Error(
+        `reliabilityHierarchy: слой «${layer.id}» ссылается на несуществующий лист «${id}»`,
+      );
+    }
+    return leaf;
+  });
+}

--- a/tools/data/check.ts
+++ b/tools/data/check.ts
@@ -82,6 +82,23 @@ for (const branch of roadmap.branches) {
   }
 }
 
+// Листья адресуются по id и по label из других файлов: иерархия надёжности
+// берёт лист по id, строка «L2-концепты» ищет его по label. Оба поиска дают
+// один узел только при уникальности имени по всей карте — два листа с общим
+// id или label превратят поиск в лотерею «кто последний в массиве».
+const allLeaves = roadmap.branches.flatMap((b) => b.l1.flatMap((l1) => leavesOf(l1)));
+for (const field of ['id', 'label'] as const) {
+  const seen = new Map<string, string>();
+  for (const leaf of allLeaves) {
+    const first = seen.get(leaf[field]);
+    if (first !== undefined) {
+      fail('листья', `${field} «${leaf[field]}» занят дважды: ${first} и ${leaf.href}`);
+    } else {
+      seen.set(leaf[field], leaf.href);
+    }
+  }
+}
+
 // Иерархия надёжности ссылается на листья своими href — это единственное
 // место, где адрес листа продублирован вне roadmap.ts. Переехал лист,
 // забыли поправить здесь — молча битая ссылка на /reliability-hierarchy/.

--- a/tools/data/check.ts
+++ b/tools/data/check.ts
@@ -99,16 +99,15 @@ for (const field of ['id', 'label'] as const) {
   }
 }
 
-// Иерархия надёжности ссылается на листья своими href — это единственное
-// место, где адрес листа продублирован вне roadmap.ts. Переехал лист,
-// забыли поправить здесь — молча битая ссылка на /reliability-hierarchy/.
-const leafHrefs = new Set(
-  roadmap.branches.flatMap((b) => b.l1.flatMap((l1) => leavesOf(l1).map((leaf) => leaf.href))),
-);
+// Иерархия надёжности называет листья по id — имя и адрес она берёт из карты
+// и потому разойтись с ней не может. Остаётся сам id: удалили или переименовали
+// лист, и слой пирамиды ссылается в пустоту. layerLeaves() на этом падает при
+// сборке, здесь то же самое читается человеческим текстом и раньше.
+const leafIds = new Set(allLeaves.map((leaf) => leaf.id));
 for (const layer of reliabilityHierarchy) {
-  for (const item of layer.leaves) {
-    if (!leafHrefs.has(item.href)) {
-      fail('reliability-hierarchy', `«${item.label}» ведёт на ${item.href}, такого листа нет`);
+  for (const id of layer.leaves) {
+    if (!leafIds.has(id)) {
+      fail('reliability-hierarchy', `слой «${layer.id}»: листа «${id}» в карте нет`);
     }
   }
 }


### PR DESCRIPTION
## Зачем

`src/data/reliabilityHierarchy.ts` хранил `label` и `href` каждого листа копией. Это было единственное место вне `roadmap.ts`, где узел карты лежал вторым экземпляром, и держалось оно на комментарии «при переименовании листа — синхронизировать». Адрес хотя бы проверялся `data-check`, имя не проверял никто: переименовал лист — пирамида молча показывает прежнее имя, ссылаясь при этом на правильную страницу.

## Что изменилось

- `HierarchyLeafRef` убран, `HierarchyLayer.leaves` стал `string[]` из id листьев.
- Добавлена `layerLeaves(layer)` — резолвит id в узел карты через `roadmap.ts`, отдаёт актуальные имя, адрес и приоритет. Неизвестный id бросает исключение и роняет сборку, а не пропускает ступень молча: слой без листьев на странице выглядит осмысленно, и опечатка дожила бы до продакшена.
- `ReliabilityPyramid.astro` рендерит через `layerLeaves()`.
- Инвариант в `tools/data/check.ts` из «href ведёт на существующий лист» стал «id есть в карте» — то же нарушение ловится раньше сборки и человеческим текстом.
- Отдельным коммитом: `check.ts` проверяет уникальность `id` и `label` листьев по всей карте. Поиск по id (пирамида) и по label (строка «L2-концепты») даёт один узел только при уникальности, но проверял это никто — комментарий в `L2Concepts.astro` обещал проверку, которой не было.

## Как проверить

`make check` зелёный целиком.

Что страница не изменилась — сборка до и после даёт побайтово одинаковый `dist/reliability-hierarchy/index.html` (84858 байт, `diff` чист). Все 20 `label` в старых данных и так совпадали с `roadmap.ts`, так что рефакторинг чисто структурный.

Что заслоны работают — проверено ломанием:

- дубль id (`playbooks` → `runbooks`) → `data-check`: «листья: id «runbooks» занят дважды: /culture/runbooks/ и /culture/playbooks/»;
- опечатка в id слоя → `data-check`: «reliability-hierarchy: слой «monitoring»: листа «symptom-vs-couse-alerting» в карте нет», и `make build` падает тем же по смыслу текстом из `layerLeaves()`.

## Риски

Breaking changes нет: экспорт `HierarchyLeafRef` удалён, но вне самого файла он нигде не использовался.
