### PR TITLE
feat(site): ссылка на исходник листа в GitHub

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -59,6 +59,15 @@ export default defineConfig({
       },
       // Соцссылки в шапке; тот же массив рендерит подвал (Footer.astro).
       social: socials,
+      // «Редактировать страницу» в подвале: Starlight клеит адрес как
+      // baseUrl + путь файла от корня репозитория, поэтому здесь ветка, а
+      // дальше подставится src/content/docs/<branch>/<slug>.md. Компонент
+      // EditLink в Footer.astro стоял всегда и молчал без этой строки.
+      // Отключить ссылку на конкретной странице — `editUrl: false` в её
+      // фронт-маттере.
+      editLink: {
+        baseUrl: 'https://github.com/jtprogru/The-Way-of-SRE/edit/main/',
+      },
       // Состав сайдбара целиком из данных: мета-страницы — src/data/nav.ts,
       // ветви, L1 и листья — src/data/roadmap.ts. Перечислять их здесь
       // руками не нужно, форму дерева задаёт src/data/sidebar.ts.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -164,7 +164,12 @@ const docNav = navFor('footer');
   )}
 
   <div class="meta sl-flex">
-    <EditLink />
+    {/*
+      На листьях ссылка на исходник живёт в карточке метаданных сверху
+      (LeafMeta.astro) — второй такой же внизу был бы дублем. На хабах,
+      мета-страницах и главной карточки нет, там остаётся штатное место.
+    */}
+    {!leafCtx && <EditLink />}
     <LastUpdated />
   </div>
   <Pagination />

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,9 +3,9 @@
 // 1) сохраняет дефолтное поведение Starlight (EditLink + LastUpdated + Pagination)
 // 2) добавляет site-wide блок снизу: doc-nav, соцссылки, копирайт, лицензия.
 //
-// Рендерится и на splash-страницах тоже, включая главную: EditLink,
-// LastUpdated и Pagination там пустые, а site-footer выводится как обычно.
-// Дублировать его инлайном в index.mdx не нужно.
+// Рендерится и на splash-страницах тоже, включая главную: LastUpdated и
+// Pagination там пустые, EditLink ведёт на сам index.mdx, а site-footer
+// выводится как обычно. Дублировать его инлайном в index.mdx не нужно.
 
 import { execSync } from 'node:child_process';
 import EditLink from 'virtual:starlight/components/EditLink';

--- a/src/components/LeafMeta.astro
+++ b/src/components/LeafMeta.astro
@@ -18,7 +18,7 @@
  * содержимого — там же, где стоял рукописный блок. На страницах вне графа
  * компонент не отдаёт ничего.
  */
-import { Aside } from '@astrojs/starlight/components';
+import { Aside, Icon } from '@astrojs/starlight/components';
 import { findPageContext, l1Href, priorityLabels } from '../data/roadmap.ts';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
@@ -30,6 +30,12 @@ const ctx = findPageContext(path);
 const leafCtx = ctx?.kind === 'leaf' ? ctx : null;
 
 const { sfia, status } = Astro.locals.starlightRoute.entry.data;
+
+// Адрес правки в GitHub Starlight считает сам из editLink.baseUrl
+// (astro.config.mjs) и пути файла. Здесь он нужен потому, что на листьях
+// штатный EditLink в подвале погашен: ссылка живёт в этой карточке, у
+// заголовка, а не внизу страницы.
+const { editUrl } = Astro.locals.starlightRoute;
 
 interface Step {
   label: string;
@@ -51,32 +57,108 @@ const priority = leafCtx ? priorityLabels[leafCtx.leaf.priority] : null;
 
 {
   leafCtx && (
-    <Aside type="note" title="Метаданные листа">
-      <ul>
-        <li>
-          <strong>Ветвь:</strong> <a href={`${base}${leafCtx.branch.href}`}>{leafCtx.branch.label}</a>
-        </li>
-        <li>
-          <strong>Путь:</strong>{' '}
-          {trail.map((step, i) => (
-            <>
-              {i > 0 && ' / '}
-              {step.href ? <a href={`${base}${step.href}`}>{step.label}</a> : step.label}
-            </>
-          ))}
-        </li>
-        {sfia && (
-          <li>
-            <strong>SFIA-уровни:</strong> {sfia.join(', ')}
-          </li>
+    <div class="leaf-meta">
+      <Aside type="note" title="Метаданные листа">
+        {editUrl && (
+          <a
+            class="leaf-meta-edit"
+            href={editUrl.href}
+            target="_blank"
+            rel="noopener"
+            title="Открыть исходник листа в редакторе GitHub"
+            aria-label="Править исходник листа на GitHub"
+          >
+            <Icon name="pencil" size="1em" />
+            <span class="leaf-meta-edit-text">Править</span>
+          </a>
         )}
-        <li>
-          <strong>Приоритет:</strong> {priority!.emoji} {priority!.ru}
-        </li>
-        <li>
-          <strong>Статус:</strong> {status}
-        </li>
-      </ul>
-    </Aside>
+        <ul>
+          <li>
+            <strong>Ветвь:</strong> <a href={`${base}${leafCtx.branch.href}`}>{leafCtx.branch.label}</a>
+          </li>
+          <li>
+            <strong>Путь:</strong>{' '}
+            {trail.map((step, i) => (
+              <>
+                {i > 0 && ' / '}
+                {step.href ? <a href={`${base}${step.href}`}>{step.label}</a> : step.label}
+              </>
+            ))}
+          </li>
+          {sfia && (
+            <li>
+              <strong>SFIA-уровни:</strong> {sfia.join(', ')}
+            </li>
+          )}
+          <li>
+            <strong>Приоритет:</strong> {priority!.emoji} {priority!.ru}
+          </li>
+          <li>
+            <strong>Статус:</strong> {status}
+          </li>
+        </ul>
+      </Aside>
+    </div>
   )
 }
+
+<style>
+  /*
+   * Кнопка правки садится на строку заголовка Aside: заголовок — чужая
+   * разметка, врезаться в неё нельзя, поэтому обёртка держит систему
+   * координат, а ссылка уходит из потока. Высота считается из тех же
+   * переменных, что и заголовок, — так она центрируется по нему при любом
+   * масштабе шрифта, а не по подобранному вручную отступу.
+   */
+  .leaf-meta {
+    position: relative;
+  }
+  /* Место под кнопку, чтобы длинный заголовок не наехал на неё. */
+  .leaf-meta :global(.starlight-aside__title) {
+    padding-inline-end: 7rem;
+  }
+
+  .leaf-meta-edit {
+    position: absolute;
+    top: 1rem;
+    inset-inline-end: 1rem;
+    height: calc(var(--sl-text-h5) * var(--sl-line-height-headings));
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0 0.5rem;
+    border: 1px solid var(--sl-color-asides-border);
+    border-radius: 4px;
+    font-size: var(--sl-text-sm);
+    font-weight: 500;
+    line-height: 1;
+    color: var(--sl-color-asides-text-accent) !important;
+    text-decoration: none !important;
+    transition: background-color 0.15s ease, color 0.15s ease;
+  }
+  .leaf-meta-edit:hover,
+  .leaf-meta-edit:focus-visible {
+    background-color: var(--sl-color-asides-border);
+    color: var(--sl-color-white) !important;
+  }
+  :root[data-theme='light'] .leaf-meta-edit:hover,
+  :root[data-theme='light'] .leaf-meta-edit:focus-visible {
+    color: var(--sl-color-bg) !important;
+  }
+
+  /* На узком экране подпись не влезает рядом с заголовком — остаётся иконка. */
+  @media (max-width: 30rem) {
+    .leaf-meta :global(.starlight-aside__title) {
+      padding-inline-end: 2.75rem;
+    }
+    .leaf-meta-edit-text {
+      display: none;
+    }
+  }
+
+  @media print {
+    .leaf-meta-edit {
+      display: none;
+    }
+  }
+</style>


### PR DESCRIPTION
## Зачем

Сайт не давал перейти от страницы к её исходнику: чтобы поправить опечатку в листе, читателю (и мне самому) надо было угадать путь в репозитории. В Starlight это штатная возможность — компонент `EditLink` стоял в подвале с самого начала и молчал, потому что в конфиге не был задан `editLink.baseUrl`.

## Что изменилось

**`astro.config.mjs`** — задан `editLink.baseUrl`. Starlight сам клеит адрес как `baseUrl + путь файла от корня репозитория`, поэтому перечислять страницы не нужно:

```
https://github.com/jtprogru/The-Way-of-SRE/edit/main/src/content/docs/culture/runbooks.md
```

**`LeafMeta.astro`** — на листьях ссылка вынесена наверх, кнопкой в правом верхнем углу карточки метаданных, на одной линии с заголовком «Метаданные листа». Внизу страницы она терялась: до неё надо доскроллить весь лист, хотя намерение «поправить» возникает там же, где читатель видит статус и приоритет.

Заголовок карточки — чужая разметка, врезаться в неё нельзя, поэтому обёртка держит систему координат, а ссылка уходит из потока. Высота считается из тех же переменных, что и заголовок (`--sl-text-h5 × --sl-line-height-headings`), — так она центрируется по нему при любом масштабе шрифта, а не по подобранному вручную отступу. Заголовку зарезервировано `7rem` справа; на экранах уже 30rem подпись прячется и остаётся иконка с `aria-label`. В печать кнопка не идёт.

**`Footer.astro`** — на листьях штатный `EditLink` погашен, иначе на одной странице было бы две одинаковые ссылки. На хабах L1, страницах ветвей, глоссарии, мета-страницах и главной подвал остаётся штатным местом.

Отключить ссылку на конкретной странице можно `editUrl: false` в её фронт-маттере.

## Как проверить

`make check` зелёный целиком: `astro check` без ошибок, 15 732 внутренние ссылки живы, стиль-чек 70 листьев чист.

В собранном `dist/` — ровно одна ссылка на страницу:

```bash
grep -o 'edit/main/[^"]*' dist/culture/runbooks/index.html   # в карточке метаданных
grep -o 'edit/main/[^"]*' dist/engineering/observability/index.html  # в подвале хаба
grep -rl 'edit/main/src' dist --include=index.html | wc -l   # 105 из 106 страниц
```

Единственные страницы без ссылки — legacy-редиректы `/sre-*/` и `/leaves/*/`, у них своего футера нет.

Глазами стоит посмотреть посадку кнопки на узком экране: `make dev`, страница `culture/runbooks`. Позиционирование проверялось арифметикой, кнопка выходит около 5.8rem при зарезервированных 7rem.

## Что осталось за кадром

Рядом в подвале так же вхолостую висит `<LastUpdated />`. Он включается одной строкой, но берёт дату из git-истории файла, а `actions/checkout` в `deploy-site.yml` идёт без `fetch-depth: 0` — на shallow-клоне даты будут враньём. Это отдельная правка, в этот PR не входит.