### PR TITLE
docs(leaves): заменить формальные «рекомендую» на честную оценку источников

### DIFF
--- a/src/content/docs/culture/dora-metrics.md
+++ b/src/content/docs/culture/dora-metrics.md
@@ -37,15 +37,15 @@ DORA делит их на две группы. **Пропускная спосо
 
 ### Книги
 
-- Nicole Forsgren, Jez Humble, Gene Kim — **[Accelerate](https://itrevolution.com/product/accelerate/)** (IT Revolution, 2018). Фундамент исходной четырёхметричной модели и методологии исследования. За текущими названиями и составом метрик сюда идти уже нельзя, рекомендую читать вместе с актуальным руководством DORA.
+- Nicole Forsgren, Jez Humble, Gene Kim — **[Accelerate](https://itrevolution.com/product/accelerate/)** (IT Revolution, 2018). Фундамент исходной четырёхметричной модели и методологии исследования. Читал бегло, для общего развития книга своё даёт, но за текущими названиями и составом метрик сюда идти уже нельзя — сверяться всё равно по актуальному руководству DORA.
 - Gene Kim, Patrick Debois, John Willis, Jez Humble — **[The DevOps Handbook](https://itrevolution.com/product/the-devops-handbook-second-edition/)** (IT Revolution, 2-е изд., 2021). Полезен как операционный контекст, но в части состава DORA-метрик устарел — за ним идти не стоит.
 
 ### Статьи и доклады
 
-- DORA — **[Software delivery performance metrics](https://dora.dev/guides/dora-metrics/)**. Сверку определений рекомендую начинать отсюда: пять метрик, группировка throughput / instability, область применения и типовые ошибки. Страница обновлена 5 января 2026 года.
+- DORA — **[Software delivery performance metrics](https://dora.dev/guides/dora-metrics/)**. Пять метрик, группировка throughput / instability, область применения и типовые ошибки. Определения сверяю по этой странице, а не по книгам: она обновляется, последняя правка — 5 января 2026 года, а книжные списки метрик к этому моменту устарели.
 - DORA — **[A history of DORA's software delivery metrics](https://dora.dev/insights/dora-metrics-history/)**. Нужен, чтобы не смешивать версии модели: отдельно объясняет переход от MTTR к failed deployment recovery time, роль reliability и добавление deployment rework rate.
 - DORA — **[Quick Check](https://dora.dev/quickcheck/)**. Подходит как вход в разговор и baseline, но не заменяет проверяемые определения и сбор событий из инженерных систем.
-- DORA — **[Capabilities catalog](https://dora.dev/capabilities/)**. Советую открывать его уже после того, как ограничение найдено: каталог предлагает практики для улучшения процесса, а не ещё один способ ранжировать команды.
+- DORA — **[Capabilities catalog](https://dora.dev/capabilities/)**. Открываю уже после того, как ограничение найдено. По моим наблюдениям, в обратном порядке каталог читается как список практик, которые надо внедрить, хотя он предлагает способ улучшить процесс, а не ещё один способ ранжировать команды.
 
 ### Инструменты
 

--- a/src/content/docs/culture/game-day.md
+++ b/src/content/docs/culture/game-day.md
@@ -34,14 +34,14 @@ Game day и chaos engineering — разные инструменты с пер�
 
 ### Книги
 
-- Betsy Beyer et al. — **[Site Reliability Engineering](https://sre.google/sre-book/accelerating-sre-on-call/)** (O'Reilly, 2016), глава 28 «Accelerating SREs to On-Call and Beyond». Источник Wheel of Misfortune как формализованной практики; рекомендую читать первым, если сталкиваетесь с темой впервые.
-- Casey Rosenthal, Nora Jones — **[Chaos Engineering: System Resiliency in Practice](https://www.oreilly.com/library/view/chaos-engineering/9781492043858/)** (O'Reilly, 2020), главы про GameDay structure и blast radius management. Рекомендую как главный практический источник по технической стороне учений с реальной инъекцией.
+- Betsy Beyer et al. — **[Site Reliability Engineering](https://sre.google/sre-book/accelerating-sre-on-call/)** (O'Reilly, 2016), глава 28 «Accelerating SREs to On-Call and Beyond». Источник Wheel of Misfortune как формализованной практики. Сам главу не читал — формат знаю по рассказам коллег, которые его у себя гоняли, и именно в этом виде он разошёлся по индустрии.
+- Casey Rosenthal, Nora Jones — **[Chaos Engineering: System Resiliency in Practice](https://www.oreilly.com/library/view/chaos-engineering/9781492043858/)** (O'Reilly, 2020), главы про GameDay structure и blast radius management. Не читал; лежит в списке по совету коллег, которые занимаются chaos engineering всерьёз, — за технической стороной учений с реальной инъекцией они отправляют сюда.
 - Kripa Krishnan — **[Weathering the Unexpected](https://queue.acm.org/detail.cfm?id=2371516)** (ACM Queue, 2012). Не книга, но обязательно к прочтению: как Google запустил DiRT и что из этого вышло. Самый ценный единичный источник про full-scale drill.
 
 ### Статьи и доклады
 
-- **[Wheel of Misfortune](https://sre.google/sre-book/accelerating-sre-on-call/)** (SRE Book, глава 28 «Accelerating SREs to On-Call and Beyond»). Описание формата ролевой тренировки: ведущий берёт реальный прошлый инцидент, участник отыгрывает дежурного. Рекомендую как стартовую точку команде, у которой ритуала ещё нет.
-- **[AWS GameDay](https://aws.amazon.com/gameday/)** — программа AWS для внешнего обучения incident response. Советую посмотреть как **референс формата** — тайм-бокс, оценка, разбор после игры, — даже если AWS вы не используете.
+- **[Wheel of Misfortune](https://sre.google/sre-book/accelerating-sre-on-call/)** (SRE Book, глава 28 «Accelerating SREs to On-Call and Beyond»). Описание формата ролевой тренировки: ведущий берёт реальный прошлый инцидент, участник отыгрывает дежурного. Команде без ритуала советую начинать с него: порог входа нулевой, нужны ведущий, час времени и один прошлый постмортем.
+- **[AWS GameDay](https://aws.amazon.com/gameday/)** — программа AWS для внешнего обучения incident response. Пробовал заводить такой формат у себя: до регулярного ритуала не дошло, я ушёл из компании раньше, но впечатление осталось хорошее. Смотреть стоит как **референс формата** — тайм-бокс, оценка, разбор после игры, — даже если AWS вы не используете.
 - Aaron Blohowiak (Netflix) — **[FIT: Failure Injection Testing](https://netflixtechblog.com/fit-failure-injection-testing-35d8e2a9bb2)** (Netflix Tech Blog, 2014). Эволюция от game day к continuous chaos; объясняет, **где game day упирается в потолок** и нужны automated experiments.
 - **[Ɔhaos Ǝnginǝǝring @ Target](https://tech.target.com/blog/chaos-engineering-at-target-part-2)** (Target Tech Blog). Один из немногих публичных взглядов изнутри на то, как крупная компания встраивает game day в обычную работу: cadence, участники, что делают с находками.
 


### PR DESCRIPTION
## Зачем

`Closes #134`. При правке в #130 в семи местах существовавшая рекомендация была переведена в первое лицо: «читать первым, если впервые сталкиваетесь с темой» стало «рекомендую читать первым». Запрет на выдуманный опыт не нарушен, но §4.3 подрос без содержания — такую фразу напишет кто угодно, включая модель.

## Что изменилось

По каждому из семи мест задан один вопрос: открывал ли я это и что вынес. Ответы записаны как есть.

**`culture/dora-metrics.md`**

- **Accelerate** — читал бегло; для общего развития книга своё даёт, но за текущим составом метрик идти нельзя.
- **Software delivery performance metrics** — определения сверяю по этой странице, а не по книгам: она обновляется, книжные списки метрик устарели.
- **Capabilities catalog** — открываю после того, как ограничение найдено; в обратном порядке каталог читается как список практик к внедрению.

**`culture/game-day.md`**

- **SRE Book, глава 28** — главу не читал, формат Wheel of Misfortune знаю по рассказам коллег, которые его у себя гоняли. Сказано прямо.
- **Wheel of Misfortune** (то же место, отдельным пунктом в «Статьях») — рекомендация оставлена, но опирается на порог входа: ведущий, час, один прошлый постмортем.
- **Chaos Engineering (Rosenthal, Jones)** — не читал, книга в списке по совету коллег, которые занимаются chaos engineering. Ранжирование «главный практический источник» убрано как не моё.
- **AWS GameDay** — пробовал заводить такой формат у себя, до регулярного ритуала не дошло, ушёл из компании раньше; впечатление осталось хорошее.

## Как проверить

`make check` — зелёный, 15 732 внутренние ссылки живы, детерминированные правила чисты.

`make style LEAF=…` по обоим листьям — 0 нарушений. Порог §4.3 удержан: `dora-metrics` 4 из 8, `game-day` 6 из 12. Это важно, потому что оба листа — единственные два из семидесяти, которые §4.3 проходят (остальные 68 в #131), и держатся они ровно на границе. Формулировки вида «не читал» сканер засчитывает как личную оценку, и #131 прямо называет это более честным вариантом, чем пустая аннотация.

## Риски

Нет: правится только текст аннотаций, состав источников и структура секций не менялись.

## Осталось за кадром

SRE Book глава 28 лежит в «Материалах» дважды — в «Книгах» и в «Статьях» под именем Wheel of Misfortune, с одной и той же ссылкой. Слить их в один пункт правильно по существу, но это уронит `game-day` до 5 из 11 и заведёт лист в #131. Оставил как есть, решать вместе с #131.
